### PR TITLE
Issue #17 - Prepare to publish AIT-Core to Pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ It is a generalization and expansion of tools developed for a number of JPL ISS 
 Getting Started
 ---------------
 
-You can read through the [Installation and Configuration Page](http://ait-core.readthedocs.io/en/latest/installation.html) for instruction on how to install BLISS Core.
+You can read through the [Installation and Configuration Page](http://ait-core.readthedocs.io/en/latest/installation.html) for instruction on how to install AIT Core.
 
 You can read through the [New Project Setup Page](http://ait-core.readthedocs.io/en/latest/project_setup.html) for
-instructions on how to use BLISS on your next project.
+instructions on how to use AIT on your next project.
 
 
 Contributing
 ------------
 
-For information on how to contribute please see the [BLISS Contributors Guides](http://ait-core.readthedocs.io/en/latest/contribute.html)
+For information on how to contribute please see the [AIT Contributors Guides](http://ait-core.readthedocs.io/en/latest/contribute.html)
 

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,23 @@
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
 
+import io
+from os import path
 from setuptools import setup, find_packages
 from setuptools.command.develop import develop
 from setuptools.command.install import install
 
 import os
 import shutil
+
+description = "Python-based software suite developed to handle Ground Data System (GDS), " \
+              "Electronic Ground Support Equipment (EGSE), commanding, telemetry uplink/downlink, " \
+              "and sequencing for JPL International Space Station and CubeSat Missions"
+
+# Get the long description from the README file
+here = path.abspath(path.dirname(__file__))
+with io.open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
 
 class InstallWithGithooks(install):
     def run(self):
@@ -32,8 +43,12 @@ class DevWithGithooks(develop):
 setup(
     name         = 'bliss-core',
     version      = '0.35.0',
+    description  = description,
+    long_description = long_description,
+    long_description_content_type = 'text/markdown',
+    url          = 'https://github.com/NASA-AMMOS/AIT-Core',
     packages     = find_packages(exclude=['tests']),
-    author       = 'BLISS-Core Development Team',
+    author       = 'AMMOS Instrument Toolkit Development Team',
     author_email = 'bliss@jpl.nasa.gov',
 
     namespace_packages   = ['bliss'],


### PR DESCRIPTION
Resolves #17. Depends on #16 and #21.

- Add descriptions and url to setup.py
- Document PyPi process in gh wiki (https://github.com/NASA-AMMOS/AIT-Core/wiki/Uploading-Releases-to-PyPi)

Test package can be seen at: https://test.pypi.org/project/bliss-core/
If this looks good I can push the package to PyPi for real.