### PR TITLE
Issue #31 - Add text and email notification support

### DIFF
--- a/bliss/core/notify.py
+++ b/bliss/core/notify.py
@@ -1,0 +1,82 @@
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+# Bespoke Link to Instruments and Small Satellites (BLISS)
+#
+# Copyright 2018, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.
+
+from email.mime.text import MIMEText
+import smtplib
+
+import bliss
+from bliss.core import log
+
+
+def trigger_notification(trigger, msg):
+    ''''''
+    email_triggers = bliss.config.get('notifications.email.triggers', [])
+    text_triggers = bliss.config.get('notifications.text.triggers', [])
+
+    if trigger in email_triggers:
+        send_email_alert(msg)
+
+    if trigger in text_triggers:
+        send_text_alert(msg)
+
+def send_email_alert(msg, recipients=None):
+    ''''''
+    if not recipients:
+        recipients = bliss.config.get('notifications.email.recipients', [])
+
+    _send_email(msg, recipients)
+
+def send_text_alert(msg, recipients=None):
+    ''''''
+    if not recipients:
+        recipients = bliss.config.get('notifications.text.recipients', [])
+
+    _send_email(msg, recipients)
+
+def _send_email(message, recipients):
+    ''''''
+    if type(recipients) != list:
+        recipients = [recipients]
+
+    if len(recipients) == 0 or any([i is None for i in recipients]):
+        m = (
+            'Email recipient list error. Unable to send email. '
+            'Recipient list length: {} Recipients: {}'
+        ).format(len(recipients), ', '.join(recipients))
+        log.error(m)
+        return
+
+    server = bliss.config.get('notifications.smtp.server', None)
+    port = bliss.config.get('notifications.smtp.port', None)
+    un = bliss.config.get('notifications.smtp.username', None)
+    pw = bliss.config.get('notifications.smtp.password', None)
+
+    if server is None or port is None or un is None or pw is None:
+        log.error('Email SMTP connection parameter error. Please check config.')
+        return
+
+    msg = MIMEText(message)
+    msg['Subject'] = 'AIT Notification'
+    msg['To'] = ', '.join(recipients)
+    msg['From'] = un
+
+    try:
+        s = smtplib.SMTP_SSL(server, port)
+        s.login(un, pw)
+        s.sendmail(un, recipients, msg.as_string())
+        s.quit()
+        log.info('Email notification sent')
+    except smtplib.SMTPException as e:
+        log.error('Failed to send email notification.')
+        log.error(e)

--- a/bliss/core/test/test_notify.py
+++ b/bliss/core/test/test_notify.py
@@ -1,0 +1,52 @@
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+# Bespoke Link to Instruments and Small Satellites (BLISS)
+#
+# Copyright 2018, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.
+
+import mock
+
+import nose
+import nose.tools
+
+import bliss.core
+from bliss.core import notify
+
+
+@mock.patch('bliss.core.notify.send_text_alert')
+@mock.patch('bliss.core.notify.send_email_alert')
+def test_trigger_notification(send_email_mock, send_text_mock):
+    bliss.config._config['notifications'] = {
+        'email': {
+            'triggers': [
+                'email-only-trigger',
+                'both-trigger'
+            ]
+        },
+        'text': {
+            'triggers': [
+                'text-only-trigger',
+                'both-trigger'
+            ]
+        }
+    }
+
+    notify.trigger_notification('email-only-trigger', 'foo')
+    send_email_mock.assert_called()
+
+    notify.trigger_notification('text-only-trigger', 'foo')
+    send_text_mock.assert_called()
+
+    send_email_mock.reset_mock()
+    send_text_mock.reset_mock()
+    notify.trigger_notification('both-trigger', 'foo')
+    send_email_mock.assert_called()
+    send_text_mock.assert_called()

--- a/data/config/config.yaml
+++ b/data/config/config.yaml
@@ -35,6 +35,38 @@ default:
     leapseconds:
         filename: leapseconds.dat
 
+    notifications:
+        email:
+            # Specifies the triggers for which a type of notification
+            # (email, text) will be emitted.
+            triggers:
+                - limit-warn
+                - limit-error
+            recipients:
+                - email@address.com
+        text:
+            triggers:
+                - limit-warn
+                - limit-error
+            # Most wireless carriers provide SMS gateways for sending
+            # texts via email. You can look up the address format for your
+            # given carrier. A list of some popular carriers is below:
+            # AT&Tnumber@txt.att.net
+            # Sprintnumber@messaging.sprintpcs.com
+            # T-Mobilenumber@tmomail.net
+            # Verizonnumber@vtext.com
+            recipients:
+                - phonenumber@service.com
+        # Notifications require connection to an SMTP server for sending
+        # both emails and texts. You should configure this to point to
+        # your SMTP server with your credentials. You can use GMails
+        # servers if you have a GMail account.
+        smtp:
+            server: smtp.gmail.com
+            port: 465
+            username: yourSMTPServerUsername
+            password: yourSMTPServerPassword
+
     phase: 'dev'
 
     data:

--- a/doc/source/bliss.core.notify.rst
+++ b/doc/source/bliss.core.notify.rst
@@ -1,0 +1,7 @@
+bliss.core.notify module
+========================
+
+.. automodule:: bliss.core.notify
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/bliss.core.rst
+++ b/doc/source/bliss.core.rst
@@ -29,6 +29,7 @@ Submodules
    bliss.core.json
    bliss.core.limits
    bliss.core.log
+   bliss.core.notify
    bliss.core.pcap
    bliss.core.seq
    bliss.core.table

--- a/doc/source/bliss.core.test.rst
+++ b/doc/source/bliss.core.test.rst
@@ -16,6 +16,7 @@ Submodules
    bliss.core.test.test_evr
    bliss.core.test.test_limits
    bliss.core.test.test_log
+   bliss.core.test.test_notify
    bliss.core.test.test_pcap
    bliss.core.test.test_table
    bliss.core.test.test_tlm

--- a/doc/source/bliss.core.test.test_notify.rst
+++ b/doc/source/bliss.core.test.test_notify.rst
@@ -1,0 +1,7 @@
+bliss.core.test.test\_notify module
+===================================
+
+.. automodule:: bliss.core.test.test_notify
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Add `bliss.core.notify` for sending email and text notifications. The
`notify` module has support for sending email and text (or both)
notifications via SMTP.

Add new bliss.config section for notifications. Notification supports
config for email and text notifications and for SMTP server connection
information.

A notification type has a list of "triggers" which specifies the name(s)
of triggers for which that type of event should be emitted. These are
used in conjunction with `bliss.config.notify.trigger_notification()`
so that components can submit triggers for notifications while allowing
the user to control what type (if any) of notification is emitted.

A notification type also has a list of "recipients". For both email and
text notifications these are email addresses.

SMTP server information is configured via 4 parameters. All of these are
expected to be set. Un-auth'ed SMTP connections are not supported.

    notifications:
        email:
            triggers:
                - limit-warn
                - limit-error
            recipients:
                - email@address.com
        text:
            triggers:
                - limit-warn
                - limit-error
            recipients:
                - phonenumber@service.com
        smtp:
            server: smtp.gmail.com
            port: 465
            username: yourSMTPServerUsername
            password: yourSMTPServerPassword

Resolve #31 