### PR TITLE
Issue #39 - Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @NASA-AMMOS/ait-committers @NASA-AMMOS/ait-project-management-committee


### PR DESCRIPTION
This should result in the committers and PMC groups being automatically included as code owners on a pull request

Resolve #39 