### PR TITLE
Issue #85 - Expand core.db backend support

### DIFF
--- a/ait/core/db.py
+++ b/ait/core/db.py
@@ -18,10 +18,13 @@ The ait.db module provides a general database storage layer for
 commands and telemetry with several backends.
 """
 
+from abc import ABCMeta, abstractmethod
+import datetime as dt
 import importlib
+import math
 
 import ait
-from ait.core import cfg, tlm
+from ait.core import cfg, cmd, dmc, dtype, evr, tlm, log
 
 
 # Backend must implement DB-API 2.0 [PEP 249]
@@ -29,6 +32,7 @@ from ait.core import cfg, tlm
 Backend = None
 
 
+@ait.deprecated('connect() will be replaced with SQLiteBackend methods in a future release')
 def connect(database):
     """Returns a connection to the given database."""
     if Backend is None:
@@ -37,6 +41,7 @@ def connect(database):
     return Backend.connect(database)
 
 
+@ait.deprecated('create() will be replaced with SQLiteBackend methods in a future release')
 def create(database, tlmdict=None):
     """Creates a new database for the given Telemetry Dictionary and
     returns a connection to it.
@@ -52,6 +57,7 @@ def create(database, tlmdict=None):
     return dbconn
 
 
+@ait.deprecated('createTable() will be replaced with SQLiteBackend methods in a future release')
 def createTable(dbconn, pd):
     """Creates a database table for the given PacketDefinition."""
     cols = ('%s %s' % (defn.name, getTypename(defn)) for defn in pd.fields)
@@ -61,12 +67,14 @@ def createTable(dbconn, pd):
     dbconn.commit()
 
 
+@ait.deprecated('getTypename() will be replaced with SQLiteBackend methods in a future release')
 def getTypename(defn):
     """Returns the SQL typename required to store the given
     FieldDefinition."""
     return 'REAL' if defn.type.float or defn.dntoeu else 'INTEGER'
 
 
+@ait.deprecated('insert() will be replaced with SQLiteBackend methods in a future release')
 def insert(dbconn, packet):
     """Inserts the given packet into the connected database."""
     values = [ ]
@@ -89,6 +97,7 @@ def insert(dbconn, packet):
     dbconn.execute(sql, values)
 
 
+@ait.deprecated('use() will be replaced with SQLiteBackend methods in a future release')
 def use(backend):
     """Use the given database backend, e.g. 'MySQLdb', 'psycopg2',
     'MySQLdb', etc.
@@ -101,6 +110,311 @@ def use(backend):
         msg = 'Could not import (load) database.backend: %s' % backend
         raise cfg.AitConfigError(msg)
 
-
 if ait.config.get('database.backend'):
     use( ait.config.get('database.backend') )
+
+
+class GenericBackend(object):
+    ''' Generic database backend abstraction
+
+    GenericBackend attempts to adequately abstract database operations into
+    a small set of common methods. Not all methods will be useful for every
+    database type and additional methods may need to be added for future
+    database support.
+
+    Generally, the expected method functionality should be
+
+        connect
+            Connect to instance of the database via the backend driver. Five
+            configuration options are respected by convention in AIT built-in
+            backend implementations if they're applicable to the given backend
+
+            database.host
+                The host to connect to. Defaults to 'localhost'
+
+            database.port
+                The port to connect to. Defaults to technology specific value
+
+            database.un
+                The username to use when connecting to the database. Defaults
+                to a technology specific value
+
+            database.pw
+                The password to use when connecting to the database. Defaults
+                to a technology specific value
+
+            database.dbname
+                The name of the database to create/use. Defaults to 'ait'
+
+        create
+            Create a database in the database instance
+
+        insert
+            Insert a packet into the database
+
+        query
+            Take a string defining a database query and return the results. The
+            format of the results is backend specific.
+
+        close
+            Close the connection to the database instance and handle any cleanup
+    '''
+
+    __metaclass__ = ABCMeta
+
+    _backend = None
+    _conn = None
+
+    @abstractmethod
+    def __init__(self):
+        try:
+            self._backend = importlib.import_module(self._backend)
+        except ImportError:
+            msg = 'Could not import (load) database.backend: %s' % self._backend
+            raise cfg.AitConfigError(msg)
+
+    @abstractmethod
+    def connect(self, **kwargs):
+        '''Connect to a backend's database instance'''
+        pass
+
+    @abstractmethod
+    def create(self, **kwargs):
+        '''Create a database in the instance'''
+        pass
+
+    @abstractmethod
+    def insert(self, packet, **kwargs):
+        '''Insert a record into the database'''
+        pass
+
+    @abstractmethod
+    def query(self, query, **kwargs):
+        '''Query the database instance and return results'''
+        pass
+
+    @abstractmethod
+    def close(self, **kwargs):
+        '''Close connection to the database instance'''
+        pass
+
+
+class InfluxDBBackend(GenericBackend):
+    ''' InfluxDB Backend Abstraction
+    
+    This requires the InfluxDB Python library to be installed and InfluxDB
+    to be installed. Note, the InfluxDB Python library is only supports up
+    to version 1.2.4. As such, this is only tested against 1.2.4. Newer
+    versions may work but are not officially supported by AIT.
+
+    https://github.com/influxdata/influxdb-python
+    https://docs.influxdata.com/influxdb
+    '''
+
+    _backend = 'influxdb'
+    _conn = None
+
+    def __init__(self):
+        ''''''
+        super(InfluxDBBackend, self).__init__()
+
+    def connect(self, **kwargs):
+        ''''''
+        host = ait.config.get('database.host', kwargs.get('host', 'localhost'))
+        port = ait.config.get('database.port', kwargs.get('port', 8086))
+        un = ait.config.get('database.un', kwargs.get('un', 'root'))
+        pw = ait.config.get('database.pw', kwargs.get('pw', 'root'))
+        dbname = ait.config.get('database.dbname', kwargs.get('database', 'ait'))
+
+        self._conn = self._backend.InfluxDBClient(host, port, un, pw)
+
+        if dbname not in [v['name'] for v in self._conn.get_list_database()]:
+            self.create(database=dbname)
+
+        self._conn.switch_database(dbname)
+
+    def create(self, **kwargs):
+        ''''''
+        dbname = ait.config.get('database.dbname', kwargs.get('database', 'ait'))
+
+        if self._conn is None:
+            raise AttributeError('Unable to create database. No connection to database exists.')
+
+        self._conn.create_database(dbname)
+        self._conn.switch_database(dbname)
+
+    def insert(self, packet, time=None, **kwargs):
+        ''''''
+        fields = {}
+        pd = packet._defn
+
+        for defn in pd.fields:
+            val = getattr(packet.raw, defn.name)
+
+            if pd.history and defn.name in pd.history:
+                val = getattr(packet.history, defn.name)
+            
+            if val is not None and not (isinstance(val, float) and math.isnan(val)):
+                fields[defn.name] = val
+
+        if len(fields) == 0:
+            log.error('No fields present to insert into Influx')
+            return
+
+        tags = kwargs.get('tags', {})
+
+        if isinstance(time, dt.datetime):
+            time = time.strftime("%Y-%m-%dT%H:%M:%S")
+
+        data = {
+            'measurement': pd.name,
+            'tags': tags,
+            'fields': fields
+        }
+
+        if time:
+            data['time'] = time
+
+        self._conn.write_points([data])
+
+    def query(self, query, **kwargs):
+        ''''''
+        return self._conn.query(query)
+
+    def close(self, **kwargs):
+        ''''''
+        if self._conn:
+            self._conn.close()
+
+    @classmethod
+    def create_packets_from_results(self, packet_name, result_set):
+        ''' Generate AIT Packets from a InfluxDB query ResultSet
+
+        Extract Influx DB query results into one packet per result entry. This
+        assumes that telemetry data was inserted in the format generated by
+        :func:`InfluxDBBackend.insert`. Complex types such as CMD16 and EVR16 are
+        evaluated if they can be properly encoded from the raw value in the
+        query result. If there is no opcode / EVR-code for a particular raw
+        value the value is skipped (and thus defaulted to 0).
+
+        Args
+            packet_name (string)
+                The name of the AIT Packet to create from each result entry
+
+            result_set (influxdb.resultset.ResultSet)
+                The query ResultSet object to convert into packets
+
+        Returns
+            A list of packets extracted from the ResultSet object or None if
+            an invalid packet name is supplied.
+                
+        '''
+        try:
+            pkt_defn = tlm.getDefaultDict()[packet_name]
+        except KeyError:
+            log.error('Unknown packet name {} Unable to unpack ResultSet'.format(packet_name))
+            return None
+
+        pkt = tlm.Packet(pkt_defn)
+
+        pkts = []
+        for r in result_set.get_points():
+            new_pkt = tlm.Packet(pkt_defn)
+
+            for f, f_defn in pkt_defn.fieldmap.iteritems():
+                field_type_name = f_defn.type.name
+                if field_type_name == 'CMD16':
+                    if cmd.getDefaultDict().opcodes.get(r[f], None):
+                        setattr(new_pkt, f, cmd_def.name)
+                elif field_type_name == 'EVR16':
+                    if evr.getDefaultDict().codes.get(r[f], None):
+                        setattr(new_pkt, f, r[f])
+                elif field_type_name == 'TIME8':
+                    setattr(new_pkt, f, r[f] / 256.0)
+                elif field_type_name == 'TIME32':
+                    new_val = dmc.GPS_Epoch + dt.timedelta(seconds=r[f])
+                    setattr(new_pkt, f, new_val)
+                elif field_type_name == 'TIME40':
+                    sec = int(r[f])
+                    microsec = r[f] * 1e6
+                    new_val = dmc.GPS_Epoch + dt.timedelta(seconds=sec, microseconds=microsec)
+                    setattr(new_pkt, f, new_val)
+                elif field_type_name == 'TIME64':
+                    sec = int(r[f])
+                    microsec = r[f] % 1 * 1e6
+                    new_val = dmc.GPS_Epoch + dt.timedelta(seconds=sec, microseconds=microsec)
+                    setattr(new_pkt, f, new_val)
+                else:
+                    try:
+                        setattr(new_pkt, f, r[f])
+                    except KeyError:
+                        log.info('Field not found in query results {} Skipping ...'.format(f))
+
+            pkts.append(new_pkt)
+        return pkts
+
+
+class SQLiteBackend(GenericBackend):
+    _backend = 'sqlite3'
+    _conn = None
+
+    def __init__(self):
+        ''''''
+        super(SQLiteBackend, self).__init__()
+
+    def connect(self, **kwargs):
+        ''''''
+        if 'database' not in kwargs:
+            kwargs['database'] = 'ait'
+
+        self._conn = self._backend.connect(kwargs['database'])
+
+    def create(self, **kwargs):
+        ''''''
+        tlmdict = kwargs.get('tlmdict', tlm.getDefaultDict())
+        
+        self.connect(**kwargs)
+
+        for name, defn in tlmdict.items():
+            self.create_table(defn)
+
+    def create_table(self, packet_defn):
+        '''Creates a database table for the given PacketDefinition.'''
+        cols = ('%s %s' % (defn.name, self._getTypename(defn)) for defn in packet_defn.fields)
+        sql  = 'CREATE TABLE IF NOT EXISTS %s (%s)' % (packet_defn.name, ', '.join(cols))
+
+        self._conn.execute(sql)
+        self._conn.commit()
+
+    def insert(self, packet, **kwargs):
+        ''''''
+        values = [ ]
+        pd     = packet._defn
+
+        for defn in pd.fields:
+            val = getattr(packet.raw, defn.name)
+
+            if val is None and defn.name in pd.history:
+                val = getattr(packet.history, defn.name)
+            
+            values.append(val)
+
+        qmark = ['?'] * len(values)
+        sql   = 'INSERT INTO %s VALUES (%s)' % (pd.name, ', '.join(qmark))
+
+
+        self._conn.execute(sql, values)
+
+    def query(self, query, **kwargs):
+        ''''''
+        return self._conn.execute(query)
+    
+    def close(self, **kwargs):
+        ''''''
+        if self._conn:
+            self._conn.close()
+
+    def _getTypename(self, defn):
+        """Returns the SQL typename required to store the given
+        FieldDefinition."""
+        return 'REAL' if defn.type.float or 'TIME' in defn.type.name or defn.dntoeu else 'INTEGER'

--- a/ait/core/dtype.py
+++ b/ait/core/dtype.py
@@ -682,6 +682,8 @@ class Time40Type(PrimitiveType):
 
         self._pdt  = self.name
         self._name = 'TIME40'
+        self._nbits = 40
+        self._nbytes = 5
 
     @property
     def pdt(self):

--- a/ait/core/test/test_db.py
+++ b/ait/core/test/test_db.py
@@ -219,12 +219,12 @@ class TestSQLiteBackend(unittest.TestCase):
 
         sqlbackend = db.SQLiteBackend()
         sqlbackend.connect = mock.MagicMock()
-        sqlbackend.create_table = mock.MagicMock()
+        sqlbackend._create_table = mock.MagicMock()
 
         sqlbackend.create(tlmdict=tlmdict)
         
         assert sqlbackend.connect.called
-        sqlbackend.create_table.assert_called_with(tlmdict['Packet1'])
+        sqlbackend._create_table.assert_called_with(tlmdict['Packet1'])
 
         os.remove(self.test_yaml_file)
 
@@ -254,7 +254,7 @@ class TestSQLiteBackend(unittest.TestCase):
         sqlbackend = db.SQLiteBackend()
         sqlbackend._conn = mock.MagicMock()
 
-        sqlbackend.create_table(tlmdict['Packet1'])
+        sqlbackend._create_table(tlmdict['Packet1'])
         sqlbackend._conn.execute.assert_called_with(
             'CREATE TABLE IF NOT EXISTS Packet1 (col1 INTEGER, SampleTime REAL)'
         )

--- a/ait/core/test/test_db.py
+++ b/ait/core/test/test_db.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python2.7
+
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+# Bespoke Link to Instruments and Small Satellites (BLISS)
+#
+# Copyright 2016, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.
+
+import datetime as dt
+import os
+import unittest
+
+import mock
+
+import ait.core.db as db
+import ait.core.tlm as tlm
+
+
+class TestInfluxDBBackend(unittest.TestCase):
+    test_yaml_file = '/tmp/test.yaml'
+
+    @mock.patch('importlib.import_module')
+    def test_influx_backend_init(self, importlib_mock):
+        sqlbackend = db.InfluxDBBackend()
+
+        importlib_mock.assert_called_with('influxdb')
+
+    @mock.patch('importlib.import_module')
+    def test_influx_connect(self, importlib_mock):
+        sqlbackend = db.InfluxDBBackend()
+        sqlbackend._backend = mock.MagicMock()
+
+        sqlbackend.connect()
+
+        # Make backend connection
+        assert sqlbackend._backend.InfluxDBClient.called
+        sqlbackend._backend.InfluxDBClient.assert_called_with(
+            'localhost', 8086, 'root', 'root'
+        )
+
+        # Switch to default database
+        assert sqlbackend._conn.switch_database.called
+        sqlbackend._conn.switch_database.assert_called_with('ait')
+        sqlbackend._backend.reset_mock()
+
+        sqlbackend.connect(database='foo')
+
+        # make backend connection
+        assert sqlbackend._backend.InfluxDBClient.called
+        sqlbackend._backend.InfluxDBClient.assert_called_with(
+            'localhost', 8086, 'root', 'root'
+        )
+
+        # Switch to custom database
+        assert sqlbackend._conn.switch_database.called
+        sqlbackend._conn.switch_database.assert_called_with('foo')
+
+    @mock.patch('importlib.import_module')
+    def test_influx_create(self, importlib_mock):
+        sqlbackend = db.InfluxDBBackend()
+        sqlbackend._backend = mock.MagicMock()
+        sqlbackend.create = mock.MagicMock()
+
+        sqlbackend.create()
+        assert sqlbackend.create.called
+
+    @mock.patch('importlib.import_module')
+    def test_influx_insert(self, importlib_mock):
+        yaml_doc = """
+        - !Packet
+          name: Packet1
+          history:
+            - col1
+          fields:
+            - !Field
+              name:       col1
+              desc:       test column 1
+              type:       MSB_U16
+              enum:
+                a: testa
+            - !Field
+              name: SampleTime
+              type: TIME64
+            - !Field
+              name: SampleTime32
+              type: TIME32
+            - !Field
+              name: SampleTime40
+              type: TIME40
+            - !Field
+              name: SampleEvr16
+              type: EVR16
+            - !Field
+              name: SampleCmd16
+              type: CMD16
+        """
+        with open(self.test_yaml_file, 'wb') as out:
+            out.write(yaml_doc)
+
+        tlmdict = tlm.TlmDict(self.test_yaml_file)
+
+        sqlbackend = db.InfluxDBBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        pkt_defn = tlmdict['Packet1']
+        pkt = tlm.Packet(pkt_defn, bytearray(xrange(pkt_defn.nbytes)))
+
+        now = dt.datetime.utcnow()
+        sqlbackend.insert(pkt, time=now)
+        sqlbackend._conn.write_points.assert_called_with([{
+            'measurement': 'Packet1',
+            'time': now.strftime('%Y-%m-%dT%H:%M:%S'),
+            'tags': {},
+            'fields': {
+                'col1': 1,
+                'SampleTime': 33752069.10112411,
+                'SampleTime32': 168496141,
+                'SampleTime40': 235868177.0703125,
+                'SampleCmd16': 5398,
+                'SampleEvr16': 4884
+            }
+        }])
+        sqlbackend._conn.reset_mock()
+
+        # Insert without a timestamp
+        sqlbackend.insert(pkt)
+        sqlbackend._conn.write_points.assert_called_with([{
+            'measurement': 'Packet1',
+            'tags': {},
+            'fields': {
+                'col1': 1,
+                'SampleTime': 33752069.10112411,
+                'SampleTime32': 168496141,
+                'SampleTime40': 235868177.0703125,
+                'SampleCmd16': 5398,
+                'SampleEvr16': 4884
+            }
+        }])
+        sqlbackend._conn.reset_mock()
+
+        # Insert with additional tags
+        sqlbackend.insert(pkt, tags={'testNum': '3'})
+        sqlbackend._conn.write_points.assert_called_with([{
+            'measurement': 'Packet1',
+            'tags': {'testNum': '3'},
+            'fields': {
+                'col1': 1,
+                'SampleTime': 33752069.10112411,
+                'SampleTime32': 168496141,
+                'SampleTime40': 235868177.0703125,
+                'SampleCmd16': 5398,
+                'SampleEvr16': 4884
+            }
+        }])
+        sqlbackend._conn.reset_mock()
+
+        os.remove(self.test_yaml_file)
+
+    @mock.patch('importlib.import_module')
+    def test_influx_query(self, importlib_mock):
+        sqlbackend = db.InfluxDBBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        sqlbackend.query('SELECT * FROM table')
+        sqlbackend._conn.query.assert_called_with('SELECT * FROM table')
+
+
+class TestSQLiteBackend(unittest.TestCase):
+    test_yaml_file = '/tmp/test.yaml'
+
+    @mock.patch('importlib.import_module')
+    def test_sqlite_backend_init(self, importlib_mock):
+        sqlbackend = db.SQLiteBackend()
+
+        importlib_mock.assert_called_with('sqlite3')
+
+    @mock.patch('importlib.import_module')
+    def test_sqlite_connect(self, importlib_mock):
+        sqlbackend = db.SQLiteBackend()
+        sqlbackend._backend = mock.MagicMock()
+
+        sqlbackend.connect()
+        assert sqlbackend._backend.connect.called
+        sqlbackend._backend.connect.assert_called_with('ait')
+        sqlbackend._backend.reset_mock()
+
+        sqlbackend.connect(database='foo')
+        assert sqlbackend._backend.connect.called
+        sqlbackend._backend.connect.assert_called_with('foo')
+
+    @mock.patch('importlib.import_module')
+    def test_sqlite_create(self, importlib_mock):
+        yaml_doc = """
+        - !Packet
+          name: Packet1
+          fields:
+            - !Field
+              name:       col1
+              desc:       test column 1
+              type:       MSB_U16
+              enum:
+                a: testa
+            - !Field
+              name: SampleTime64
+              type: TIME64
+        """
+        with open(self.test_yaml_file, 'wb') as out:
+            out.write(yaml_doc)
+
+        tlmdict = tlm.TlmDict(self.test_yaml_file)
+
+        sqlbackend = db.SQLiteBackend()
+        sqlbackend.connect = mock.MagicMock()
+        sqlbackend.create_table = mock.MagicMock()
+
+        sqlbackend.create(tlmdict=tlmdict)
+        
+        assert sqlbackend.connect.called
+        sqlbackend.create_table.assert_called_with(tlmdict['Packet1'])
+
+        os.remove(self.test_yaml_file)
+
+    @mock.patch('importlib.import_module')
+    def test_sqlite_create_table(self, importlib_mock):
+        yaml_doc = """
+        - !Packet
+          name: Packet1
+          history:
+            - col1
+          fields:
+            - !Field
+              name:       col1
+              desc:       test column 1
+              type:       MSB_U16
+              enum:
+                a: testa
+            - !Field
+              name: SampleTime
+              type: TIME64
+        """
+        with open(self.test_yaml_file, 'wb') as out:
+            out.write(yaml_doc)
+
+        tlmdict = tlm.TlmDict(self.test_yaml_file)
+
+        sqlbackend = db.SQLiteBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        sqlbackend.create_table(tlmdict['Packet1'])
+        sqlbackend._conn.execute.assert_called_with(
+            'CREATE TABLE IF NOT EXISTS Packet1 (col1 INTEGER, SampleTime REAL)'
+        )
+
+        os.remove(self.test_yaml_file)
+
+    @mock.patch('importlib.import_module')
+    def test_sqlite_insert(self, importlib_mock):
+        yaml_doc = """
+        - !Packet
+          name: Packet1
+          history:
+            - col1
+          fields:
+            - !Field
+              name:       col1
+              desc:       test column 1
+              type:       MSB_U16
+              enum:
+                a: testa
+            - !Field
+              name: SampleTime
+              type: TIME64
+        """
+        with open(self.test_yaml_file, 'wb') as out:
+            out.write(yaml_doc)
+
+        tlmdict = tlm.TlmDict(self.test_yaml_file)
+
+        sqlbackend = db.SQLiteBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        pkt_defn = tlmdict['Packet1']
+        pkt = tlm.Packet(pkt_defn, bytearray(xrange(pkt_defn.nbytes)))
+
+        sqlbackend.insert(pkt)
+        sqlbackend._conn.execute.assert_called_with(
+            'INSERT INTO Packet1 VALUES (?, ?)', [1, 33752069.10112411]
+        )
+
+        os.remove(self.test_yaml_file)

--- a/doc/source/ait.core.test.rst
+++ b/doc/source/ait.core.test.rst
@@ -11,6 +11,7 @@ Submodules
    ait.core.test.test_cfg
    ait.core.test.test_cmd
    ait.core.test.test_coord
+   ait.core.test.test_db
    ait.core.test.test_dmc
    ait.core.test.test_dtype
    ait.core.test.test_evr

--- a/doc/source/ait.core.test.test_db.rst
+++ b/doc/source/ait.core.test.test_db.rst
@@ -1,0 +1,7 @@
+ait.core.test.test\_db module
+=============================
+
+.. automodule:: ait.core.test.test_db
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/databases.rst
+++ b/doc/source/databases.rst
@@ -1,0 +1,6 @@
+AIT Database API
+================
+
+AIT provides a general database abstraction class on top of which custom implementations can be written. AIT comes packaged with abstractions for InfluxDB (:class:`ait.core.db.InfluxDBBackend`)and SQLite (:class:`ait.core.db.SQLiteBackend`). You can inherit from the abstract base class :class:`ait.core.db.GenericBackend` and implement your own database abstraction.
+
+.. autoclass:: ait.core.db.GenericBackend

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -20,6 +20,7 @@ Visit the :doc:`Installation and Environment Configuration <installation>` guide
    API Module Introduction <api_intro>
    EVR Introduction <evr_intro>
    limits_intro
+   Database API <databases>
    Command & Data Handling Tables <c_and_dh_intro>
    bsc_intro
 


### PR DESCRIPTION
Add the GenericBackend abstract base class in core.db for defining the
expected interface for interacting with databases through AIT. Add
the SQLiteBackend sub-class which implements the previous core.db
backend functionality. Add the InfluxDBBackend sub-class which adds
support for InfluxDB to the toolkit.

Deprecate all previous core.db functions. Users should instead use the
SQLiteBackend class if they require the previous functionality. All
previous core.db functions will be removed in a future release.

Add tests for the new core.db backend classes

Update ait-tlm-db-insert to use the new backend classes. It also expects
to receive data in PCAPs instead of generic binary blobs in a file since
PCAPs are the project baseline for data storage.

Resolve #81 
Resolve #85 