### PR TITLE
Issue #65 - Fix git hooks install on non-checkout version of repo

### DIFF
--- a/build/githooks/pre-commit
+++ b/build/githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 pre_api_build=`git ls-files -m | wc -l`
-sphinx-apidoc --separate --force --no-toc -o doc/source bliss bliss/test &> /dev/null
+sphinx-apidoc --separate --force --no-toc -o doc/source ait ait/test &> /dev/null
 post_api_build=`git ls-files -m | wc -l`
 
 if [[ $pre_api_build -ne $post_api_build ]]; then

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ import io
 from os import path
 from setuptools import setup, find_packages
 from setuptools.command.develop import develop
-from setuptools.command.install import install
 
 import os
 import shutil
@@ -30,15 +29,11 @@ here = path.abspath(path.dirname(__file__))
 with io.open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-class InstallWithGithooks(install):
-    def run(self):
-        install.run(self)
-        shutil.copy('./build/githooks/pre-commit', '.git/hooks')
-
 class DevWithGithooks(develop):
     def run(self):
         develop.run(self)
-        shutil.copy('./build/githooks/pre-commit', '.git/hooks')
+        if path.exists('.git/hooks'):
+            shutil.copy('./build/githooks/pre-commit', '.git/hooks')
 
 setup(
     name         = 'ait-core',
@@ -93,7 +88,6 @@ setup(
     },
 
     cmdclass = {
-        'develop': DevWithGithooks,
-        'install': InstallWithGithooks
+        'develop': DevWithGithooks
     }
 )


### PR DESCRIPTION
Git hook install now checks to make sure that the .git/hooks directory
exists before attempting to copy the hook script into location. This
ensures no error shows up when installing from a non-cloned version of
the code base.

Remove the git hook install from non-develop mode installs. If someone
is installing the toolkit in 'install' mode instead of 'develop' mode
the likelihood of them making changes that the hook would catch seems
slim.

Update the packaging naming in the git hook

Resolve #65 