### PR TITLE
Issue #97: add configurable subject and from address

### DIFF
--- a/ait/core/notify.py
+++ b/ait/core/notify.py
@@ -66,15 +66,20 @@ def _send_email(message, recipients):
         log.error('Email SMTP connection parameter error. Please check config.')
         return
 
+    subject = ait.config.get('notifications.smtp.subject', 'AIT Notification')
+
+    # From address must have a valid @server, otherwise texts will not works
+    fromaddr = ait.config.get('notifications.smtp.from', 'ait-notify@%s' % server)
+
     msg = MIMEText(message)
-    msg['Subject'] = 'AIT Notification'
+    msg['Subject'] = subject
     msg['To'] = ', '.join(recipients)
-    msg['From'] = un
+    msg['From'] = fromaddr
 
     try:
         s = smtplib.SMTP_SSL(server, port)
         s.login(un, pw)
-        s.sendmail(un, recipients, msg.as_string())
+        s.sendmail(fromaddr, recipients, msg.as_string())
         s.quit()
         log.info('Email notification sent')
     except smtplib.SMTPException as e:


### PR DESCRIPTION
* Subject defaults to 'AIT Notification'.
* From defaults to 'ait-notify@my.smtp.server'

This update also includes a bug fix for s.sendmail(). First argument is
supposed to be from_addr [1]:

  SMTP.sendmail(from_addr, to_addrs, msg[, mail_options, rcpt_options])

[1] https://docs.python.org/2/library/smtplib.html#smtplib.SMTP.sendmail.

Testing in past must have used SMTP server that did not check to verify
from_addr was an email format (e.g. ait@gmail.com).

Another note from testing is the from_addr MUST have a valid @server in
order to work for text messaging. At least while testing with AT&T, it appears
they perform a check to verify it is a legitimate domain prior to sending.
Interestingly enough, it does not bounce the message with an error, it
simply drops it to the floor.

Resolves #97 