### PR TITLE
Issue #79: ait-pcap help message cleanup

### DIFF
--- a/ait/core/bin/ait_pcap.py
+++ b/ait/core/bin/ait_pcap.py
@@ -48,14 +48,14 @@ def main():
         '--stime': {
             'default' : dmc.GPS_Epoch,
             'help'    : ('Starting time for desired telemetry range in '
-                         'ISO 8601 Format "YYYY-MM-DDThh:mm:SSZ" (default: '
+                         'ISO 8601 Format "YYYY-MM-DDThh:mm:ssZ" (default: '
                          '1980-01-06T00:00:00Z)')
         },
 
         '--etime': {
             'default' : datetime.datetime.now(),
             'help'    : ('Ending time for desired telemetry range in '
-                         'ISO 8601 Format "YYYY-MM-DDThh:mm:SSZ" (default: '
+                         'ISO 8601 Format "YYYY-MM-DDThh:mm:ssZ" (default: '
                          'the current time; example: 2018-05-23T18:54:31Z)')
         },
 
@@ -111,7 +111,7 @@ def main():
             ap.print_help()
             print
             print
-            raise ValueError("Start and end time must be formatted as YY-MM-DDThh:mm:SSZ")
+            raise ValueError("Start and end time must be formatted as YYYY-MM-DDThh:mm:ssZ")
 
         pcap.query(starttime, endtime, output, *pcapfiles)
 

--- a/ait/core/bin/ait_pcap.py
+++ b/ait/core/bin/ait_pcap.py
@@ -48,13 +48,15 @@ def main():
         '--stime': {
             'default' : dmc.GPS_Epoch,
             'help'    : ('Starting time for desired telemetry range in '
-                         'ISO 8601 Format "YY-MM-DDThh:mm:SSZ"')
+                         'ISO 8601 Format "YYYY-MM-DDThh:mm:SSZ" (default: '
+                         '1980-01-06T00:00:00Z)')
         },
 
         '--etime': {
             'default' : datetime.datetime.now(),
             'help'    : ('Ending time for desired telemetry range in '
-                         'ISO 8601 Format "YY-MM-DDThh:mm:SSZ"')
+                         'ISO 8601 Format "YYYY-MM-DDThh:mm:SSZ" (default: '
+                         'the current time; example: 2018-05-23T18:54:31Z)')
         },
 
         '--output': {


### PR DESCRIPTION
Updated --stime and --etime flag help messages. Updated formats to
YY-MM-DDThh:mm:SSZ, and updated defaults and examples to match this
format. Updated etime default to "current time" rather than an example
time, and relabeled the provided time "example".