### PR TITLE
Issue #101: ait-tlm-csv warning when field not detected results in a …

### DIFF
--- a/ait/core/bin/ait_tlm_csv.py
+++ b/ait/core/bin/ait_tlm_csv.py
@@ -159,7 +159,7 @@ def main():
                                 fieldVal = str(fieldVal)
 
                         except KeyError:
-                            log.warn('%s not found in Packet' % field)
+                            log.debug('%s not found in Packet' % field)
                             fieldVal = None
                         except ValueError:
                             # enumeration not found. just get the raw value


### PR DESCRIPTION
…lot of spam

Decreased the logging level of the message from 'warning' to 'debug' so
that it will not show up in the logs, which are set to the 'info' level.