### PR TITLE
Issue #112 - Expand EVR Format Message Handling

### DIFF
--- a/ait/core/dtype.py
+++ b/ait/core/dtype.py
@@ -70,7 +70,7 @@ import datetime
 import struct
 import sys
 
-from ait.core import cmd, dmc, evr, log, util
+from ait.core import cmd, dmc, log, util
 
 
 # PrimitiveTypes
@@ -535,6 +535,7 @@ class EVRType(PrimitiveType):
     def evrs(self):
         """Getter EVRs dictionary"""
         if self._evrs is None:
+            import ait.core.evr as evr
             self._evrs = evr.getDefaultDict()
 
         return self._evrs

--- a/ait/core/test/test_evr.py
+++ b/ait/core/test/test_evr.py
@@ -41,10 +41,21 @@ def test_evr_message_format_single_formatter():
 def test_evr_message_format_multiple_formatters():
     evr_dicts = evr.getDefaultDict()
     example = evr_dicts.codes[1]
-    example.message = "Unexpected length for %c command %s and %d."
+    example.message = "Unexpected length for %c command %s and %u."
     input_data = bytearray([0x21, 0x46, 0x6f, 0x6f, 0x00, 0xff, 0x11, 0x33, 0x44])
 
     expected = "Unexpected length for ! command Foo and 4279317316."
+    result = example.format_message(input_data)
+
+    assert result == expected
+
+def test_evr_message_format_complex_formatters():
+    evr_dicts = evr.getDefaultDict()
+    example = evr_dicts.codes[1]
+    example.message = "Unexpected length for %c command %s and %llu."
+    input_data = bytearray([0x21, 0x46, 0x6f, 0x6f, 0x00, 0x80, 0x00, 0x00, 0x00, 0xff, 0x11, 0x33, 0x44])
+
+    expected = "Unexpected length for ! command Foo and 9223372041134093124."
     result = example.format_message(input_data)
 
     assert result == expected
@@ -70,4 +81,91 @@ def test_bad_formatter_parsing():
         assert False
     except ValueError as e:
         assert e.message == msg
-        assert True
+
+def test_standard_formatter_handling():
+    evr_dicts = evr.getDefaultDict()
+    example = evr_dicts.codes[1]
+
+    example.message = '%c'
+    result = example.format_message(
+        bytearray([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+    )
+    assert result == '\x01'
+
+    example.message = '%d'
+    result = example.format_message(
+        bytearray([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+    )
+    assert result == '16909060'
+
+    example.message = '%u'
+    result = example.format_message(
+        bytearray([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+    )
+    assert result == '16909060'
+
+    example.message = '%i'
+    result = example.format_message(
+        bytearray([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+    )
+    assert result == '16909060'
+
+    example.message = '%x'
+    result = example.format_message(bytearray([0x00, 0x00, 0x00, 0x0f]))
+    assert result == 'f'
+
+    example.message = '%X'
+    result = example.format_message(bytearray([0x00, 0x00, 0x00, 0x0f]))
+    assert result == 'F'
+
+    example.message = '%f'
+    result = example.format_message(bytearray([
+        0x40, 0x5E, 0xDC, 0x14, 0x5D, 0x85, 0x16, 0x55
+    ]))
+    assert result == '123.438743'
+
+    example.message = '%e'
+    result = example.format_message(bytearray([
+        0x40, 0x5E, 0xDC, 0x14, 0x5D, 0x85, 0x16, 0x55
+    ]))
+    assert result == '1.234387e+02'
+
+    example.message = '%E'
+    result = example.format_message(bytearray([
+        0x40, 0x5E, 0xDC, 0x14, 0x5D, 0x85, 0x16, 0x55
+    ]))
+    assert result == '1.234387E+02'
+
+    example.message = '%g'
+    result = example.format_message(bytearray([
+        0x40, 0x5E, 0xDC, 0x14, 0x5D, 0x85, 0x16, 0x55
+    ]))
+    assert result == '123.439'
+
+def test_complex_formatter_handling():
+    evr_dicts = evr.getDefaultDict()
+    example = evr_dicts.codes[1]
+
+    example.message = '%hhu'
+    result = example.format_message(
+        bytearray([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+    )
+    assert result == '1'
+
+    example.message = '%hu'
+    result = example.format_message(
+        bytearray([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+    )
+    assert result == '258'
+
+    example.message = '%lu'
+    result = example.format_message(
+        bytearray([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+    )
+    assert result == '16909060'
+
+    example.message = '%llu'
+    result = example.format_message(
+        bytearray([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+    )
+    assert result == '72623859790382856'


### PR DESCRIPTION
EVR message format string processing has been updated to better handle
type and size format information. Data conversion has been switched over
to the dtype.PrimitiveType class so that processing of binary values
into ints/floats returns expected values.

Resolve #112