### PR TITLE
Issue #75 - Create script for generating dummy telemetry data for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ src/doc/dict/cmd/cmddict-07-cmddefs.tex
 
 # Nosetests ouptut file
 nosetests.xml
+
+# Macintosh file
+*.DS_Store

--- a/ait/core/bin/ait_tlm_simulate.py
+++ b/ait/core/bin/ait_tlm_simulate.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+# Bespoke Link to Instruments and Small Satellites (BLISS)
+#
+# Copyright 2013, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.
+
+'''
+Usage: ait-tlm-simulate [options] 
+
+Sends simulated telemetry.
+
+  --port=number       Port to which to send data       (default:3076)
+  --host=string       Host to which to send data       (default:'127.0.0.1')
+  --packetName=str    String name of packetDefn        (default:None)
+  --packetFill        Byte to fill packet with         (default:None)
+
+If no packetName specified, will choose the first available packetDefn.
+If no packetFill specified, will fill packet using xrange. 
+
+Examples:
+
+  $ ait-tlm-simulate 
+
+'''
+
+
+import sys
+import socket
+import time
+import argparse
+
+from ait.core import log, tlm
+
+
+def main():
+    try:
+        log.begin()
+
+        parser = argparse.ArgumentParser(
+                    description=__doc__,
+                    formatter_class=argparse.RawDescriptionHelpFormatter)
+
+        # Add optional command line arguments
+        parser.add_argument('--port', default=3076, type=int)
+        parser.add_argument('--host', default='127.0.0.1', type=str)
+        parser.add_argument('--packetName', default=None)
+        parser.add_argument('--packetFill', default=None)
+
+        # Get command line arguments
+        args = vars(parser.parse_args())
+
+        port = args['port']
+        host = args['host']
+        fill = args['packetFill']
+        name = args['packetName']
+
+        if name:
+            defn = tlm.getDefaultDict()[name] 
+        else:
+            defn = tlm.getDefaultDict().values()[0]
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+        packet = defn.simulate(fill=fill)
+
+        while True:
+            sock.sendto(packet._data, (host, port))
+
+            log.info('Sent telemetry (%d bytes) to %s:%d' 
+                        % (packet.nbytes, host, port))
+
+            time.sleep(1)
+
+    except KeyboardInterrupt:
+      log.info('Received Ctrl-C. Stopping telemetry stream.')
+
+    except Exception as e:
+      log.error('TLM send error: %s' % str(e))
+
+    log.end()
+
+if __name__ == '__main__':
+    main()

--- a/ait/core/bin/ait_tlm_simulate.py
+++ b/ait/core/bin/ait_tlm_simulate.py
@@ -34,7 +34,6 @@ Examples:
 '''
 
 
-import sys
 import socket
 import time
 import argparse

--- a/ait/core/bin/ait_tlm_simulate.py
+++ b/ait/core/bin/ait_tlm_simulate.py
@@ -3,7 +3,7 @@
 # Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
 # Bespoke Link to Instruments and Small Satellites (BLISS)
 #
-# Copyright 2013, by the California Institute of Technology. ALL RIGHTS
+# Copyright 2018, by the California Institute of Technology. ALL RIGHTS
 # RESERVED. United States Government Sponsorship acknowledged. Any
 # commercial use must be negotiated with the Office of Technology Transfer
 # at the California Institute of Technology.

--- a/ait/core/tlm.py
+++ b/ait/core/tlm.py
@@ -645,6 +645,11 @@ class PacketDefinition(json.SlotSerializer, object):
         return obj
 
 
+    def simulate(self, fill=None):
+        size   = self.nbytes
+        values = xrange(size) if fill is None else ((fill,) * size)
+        return Packet(self, bytearray(values))
+
 
 class PacketExpression(object):
     """PacketExpression


### PR DESCRIPTION
Added `simulate` method to `PacketDefinition` class and used it to send dummy packet data to host and port of choice in `ait_tlm_simulate.py`.

Resolves #75 