### PR TITLE
Issue #25 - bliss_cmd_send hardcoded to 127.0.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ src/doc/dict/cmd/cmddict-07-cmddefs.tex
 
 # Nosetests ouptut file
 nosetests.xml
+
+# Macintosh file
+*.DS_Store

--- a/ait/core/bin/ait_cmd_send.py
+++ b/ait/core/bin/ait_cmd_send.py
@@ -47,6 +47,11 @@ def main():
             'default' : ait.config.get('command.port', ait.DEFAULT_CMD_PORT),
             'help'    : 'Port on which to send data'
         },
+        '--host': {
+            'type'    : str,
+            'default' : "127.0.0.1",
+            'help'    : 'Host to which to send data'
+        },
         '--verbose': {
             'action'  : 'store_true',
             'default' : False,
@@ -68,7 +73,7 @@ def main():
 
     args = gds.arg_parse(arguments, description)
 
-    host     = "127.0.0.1"
+    host     = args.host
     port     = args.port
     verbose  = args.verbose
     cmd = api.CmdAPI(port, verbose=verbose)


### PR DESCRIPTION
Added `host` argument to `ait_cmd_send.py` script which defaults to `"127.0.0.1"`.

Resolves #25 