### PR TITLE
Issue #124 - Config file reload on test initialization uses relative path

### DIFF
--- a/ait/core/test/__init__.py
+++ b/ait/core/test/__init__.py
@@ -26,7 +26,6 @@ import ait
 import ait.core
 
 
-ait.config.reload('config/config.yaml')
 
 def setUp():
     """Set up tests.


### PR DESCRIPTION
Removing reload of default config file on test initialization.

Resolves #124 