### PR TITLE
Issue #129: Update EVRType to better handle unknown EVRs

### DIFF
--- a/ait/core/dtype.py
+++ b/ait/core/dtype.py
@@ -574,11 +574,11 @@ class EVRType(PrimitiveType):
 
         if raw:
             result = code
-        else:
+        elif code in self.evrs.codes:
             result = self.evrs.codes[code]
-
-        if result is None:
-            raise ValueError('Unrecognized EVR code: %d' % code)
+        else:
+            result = code
+            log.warn('Unrecognized EVR code: %d' % code)
 
         return result
 


### PR DESCRIPTION
Current functionality did not properly handle unknown EVRs. This provides
more graceful handling to output warning messages versus raising
and exception.

resolves #129 