### PR TITLE
Issue #138 - Updated python requests version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'bottle==0.12.9',
         'jsonschema==2.5.1',
         'pyyaml==3.11',
-        'requests==2.9.1',
+        'requests>=2.17.0',
         'gevent==1.1.2',
         'gevent-websocket==0.9.5',
     ],


### PR DESCRIPTION
influxDB requires requests>=2.17.0 while AIT-CORE required 2.9.1. Upgraded to the required version number. Change was tested out by sending sequences via AIT GUI.