### PR TITLE
Issue #149 - Update default log_stream port

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -118,7 +118,7 @@ default:
             - stream:
                 name: log_stream
                 input: 
-                    - 3077
+                    - 2514
 
             - stream:
                 name: telem_stream


### PR DESCRIPTION
Update the server section of config.yaml so the log_stream port is set to 2514 (the expected log port in the rest of the toolkit)

Resolve #149