### PR TITLE
Issue #66 - Strarg validation includes err mesg when arg is numeric

### DIFF
--- a/ait/core/dtype.py
+++ b/ait/core/dtype.py
@@ -269,8 +269,12 @@ class PrimitiveType(object):
                     msg = prefix + ' ' + tok[0].lower() + " " + " ".join(tok[1:])
                 messages.append(msg)
 
+
         if self.string:
-            valid = type(value) is str
+            if type(value) is str:
+                valid = True
+            else:
+                log("Value '%s' is not a string type." % str(value))
         else:
             if type(value) is str:
                 log("String '%s' cannot be represented as a number." % value)

--- a/ait/core/test/test_dtype.py
+++ b/ait/core/test/test_dtype.py
@@ -208,6 +208,40 @@ def testget():
     with nose.tools.assert_raises(ValueError):
         dtype.get('U8[-42]')
 
+def testString():
+    dt = dtype.get("S16")
+    assert isinstance(dt, dtype.PrimitiveType)
+    assert dt.string
+    assert not dt.float
+    assert not dt.signed
+    assert dt.name == "S16"
+    assert dt.nbytes == 16
+    assert dt.nbits == (16 * 8)
+
+    dt = dtype.get("S32")
+    assert isinstance(dt, dtype.PrimitiveType)
+    assert dt.string
+    assert not dt.float
+    assert not dt.signed
+    assert dt.name == "S32"
+    assert dt.nbytes == 32
+    assert dt.nbits == (32 * 8)
+
+    ival = 1
+    errmsgs = []
+    assert not dt.validate(ival, errmsgs)
+    assert errmsgs
+
+    fval = 1.1
+    errmsgs = []
+    assert not dt.validate(fval, errmsgs)
+    assert errmsgs
+
+    sval = "1"
+    errmsgs = []
+    assert dt.validate(sval)
+    assert not errmsgs
+
 
 if __name__ == '__main__':
     nose.main()

--- a/config/cmd.yaml
+++ b/config/cmd.yaml
@@ -67,3 +67,19 @@
       bytes: [0,1]
       value: 5
 
+- !Command
+  name:      SEND_STR_ARG
+  opcode:    0x0005
+  subsystem: CMD
+  title: Send string argument value
+  desc:      |
+    This command tests sending a single string argument.
+
+  arguments:
+    - !Argument
+      name: str_arg
+      desc: String Argument
+      units: none
+      type: S16
+      bytes: [0,15]
+


### PR DESCRIPTION
Also added new example command to the cmd.yaml that has a single string argument.  Resolves #66 