### PR TITLE
Issue #168 - CmdApi has new method for parsing arguments via cmd-arg …

### DIFF
--- a/ait/core/bin/ait_cmd_send.py
+++ b/ait/core/bin/ait_cmd_send.py
@@ -76,8 +76,12 @@ def main():
     host     = args.host
     port     = args.port
     verbose  = args.verbose
-    cmd = api.CmdAPI(port, verbose=verbose)
-    cmd.send(args.command, *args.arguments)
+
+    cmdApi  = api.CmdAPI(port, verbose=verbose)
+
+    cmdArgs = cmdApi.parseArgs(args.command, *args.arguments)
+
+    cmdApi.send(args.command, *cmdArgs)
 
     log.end()
 

--- a/ait/core/bin/ait_seq_send.py
+++ b/ait/core/bin/ait_seq_send.py
@@ -90,6 +90,7 @@ def main ():
                     delay    = float(tokens[0])
                     name     = tokens[1]
                     args     = [ util.toNumber(t, t) for t in tokens[2:] ]
+                    args     = cmd.parseArgs(name, *args)
                     time.sleep(delay)
                     log.info(line)
                     cmd.send(name, *args)


### PR DESCRIPTION
…definitions.
The ait_cmd_send.py script was updated to call this parseArgs method, passing in the argument array retrieved from argparse.  
The results of the cmdApi.parseArgs() is then passed as the 'argument-list' parameter to the cmdApi.send() method.
The ait_seq_send.py was also updated to call this new method prior to sending arguments.