### PR TITLE
Issue #127 - Fixed bugs caused by Ethernet_HS_Packet definition

### DIFF
--- a/config/tlm.yaml
+++ b/config/tlm.yaml
@@ -51,7 +51,7 @@
       type:  MSB_U32
       value: 0x01234567
     - !Field
-      name:  time
+      name:  time_created
       type:  TIME64
       desc:  Time when data product created (seconds since GPS/ISS epoch)
     - !Field
@@ -62,7 +62,6 @@
         1: TABLE_BAR
         2: MEM_DUMP
         3: HEALTH_AND_STATUS
-      when: product_type == 3
     - !Field
       name: product_length
       type: MSB_U32


### PR DESCRIPTION
Resolves #127 
1. The line 'when: product_type == 3' in the 'product_type' field of the Ethernet_HS_Packet definition causes an infinite recursion.
2. The 'time' field of the Ethernet_HS_Packet definition fails to insert into the InfluxDB database because InfluxDB has a meta column named 'time'. It has been changed to 'time_created' as a temporary fix.