### PR TITLE
Issue #167 - Add !include capability to cmd.yaml

### DIFF
--- a/ait/core/cmd.py
+++ b/ait/core/cmd.py
@@ -462,7 +462,9 @@ class CmdDict(dict):
             else:
                 stream        = content
 
-            for cmd in yaml.load(stream):
+            cmds = yaml.load(stream)
+            cmds = handle_includes(cmds)
+            for cmd in cmds:
                 self.add(cmd)
 
             if type(stream) is file:
@@ -496,6 +498,22 @@ def getMaxCmdSize():
     removes 1 word for CCSDS header (-1)
     """
     return (MAX_CMD_WORDS - 1) * 2
+
+
+def handle_includes(defns):
+    '''Recursive handling of includes for any input list of defns.
+    The assumption here is that when an include is handled by the
+    pyyaml reader, it adds them as a list, which is stands apart from the rest
+    of the expected YAML definitions.
+    '''
+    newdefns = []
+    for d in defns:
+        if isinstance(d,list):
+            newdefns.extend(handle_includes(d))
+        else:
+            newdefns.append(d)
+
+    return newdefns
 
 
 def YAMLCtor_ArgDefn(loader, node):

--- a/ait/core/cmd.py
+++ b/ait/core/cmd.py
@@ -509,6 +509,15 @@ def YAMLCtor_CmdDefn(loader, node):
     fields['argdefns'] = fields.pop('arguments', None)
     return createCmdDefn(**fields)
 
+def YAMLCtor_include(loader, node):
+    # Get the path out of the yaml file
+    name = os.path.join(os.path.dirname(loader.name), node.value)
+    data = None
+    with open(name,'r') as f:
+        data = yaml.load(f)
+    return data
+
+yaml.add_constructor('!include' , YAMLCtor_include)
 yaml.add_constructor('!Command' , YAMLCtor_CmdDefn)
 yaml.add_constructor('!Argument', YAMLCtor_ArgDefn)
 yaml.add_constructor('!Fixed'   , YAMLCtor_ArgDefn)

--- a/ait/core/data/cmd_schema.json
+++ b/ait/core/data/cmd_schema.json
@@ -1,12 +1,19 @@
 {
-	"$schema": "http://json-schema.org/draft-04/schema#",
-	"title": "Command Dictionary Schema",
-	"description": "Command Dictionary Schema",
-	"type": "array",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Command Dictionary Schema",
+    "description": "Command Dictionary Schema",
+    "type": "array",
     "items": {
-        "required": ["command", "name", "opcode"],
+        "oneOf" : [{
+            "required": ["command", "name", "opcode"]
+            }, {
+            "required" : ["include"]
+        }],
         "additionalProperties": false,
         "properties": {
+            "include": {
+                "type": "string"
+            },
             "command": {
                 "type": "string"
             },
@@ -32,8 +39,15 @@
                         {
                             "type": "object",
                             "additionalProperties": false,
-                            "required": ["argument", "name", "type", "bytes"],
+                            "oneOf" : [{
+                            "required": ["argument", "name", "type", "bytes"]
+                                }, {
+                            "required": ["include"]
+                            }],
                             "properties": {
+                                "include": {
+                                    "type": "string"
+                                },
                                 "argument": {
                                     "type": "string"
                                 },
@@ -68,8 +82,15 @@
                         {
                             "type": "object",
                             "additionalProperties": false,
-                            "required": ["fixed", "type", "bytes"],
+                            "oneOf" : [{
+                            "required": ["fixed", "type", "bytes"]
+                                }, {
+                            "required": ["include"]
+                            }],
                             "properties": {
+                                "include": {
+                                    "type": "string"
+                                },
                                 "fixed": {
                                     "type": "string"
                                 },

--- a/config/cmd.yaml
+++ b/config/cmd.yaml
@@ -8,7 +8,7 @@
 
 - !Command
   name:      SEQ_START
-  opcode:    0x002
+  opcode:    0x0002
   subsystem: CMD
   title: Start Sequence
   desc:      |
@@ -83,3 +83,5 @@
       type: S16
       bytes: [0,15]
 
+# below is example of including additional command dictionary file
+- !include core_set_op_mode.yaml

--- a/config/core_set_op_mode.yaml
+++ b/config/core_set_op_mode.yaml
@@ -1,13 +1,13 @@
 # An example command for setting the operation
 # mode of an instrument.
---- !Command
-name:      CORE_SET_OP_MODE
-opcode:    0x0006
-subsystem: CORE
-desc:      |
-  This command sets the operational mode.
+- !Command
+  name:      CORE_SET_OP_MODE
+  opcode:    0x0006
+  subsystem: CORE
+  desc:      |
+    This command sets the operational mode.
 
-arguments:
+  arguments:
   - !Argument
     name:  mode
     desc:  Mode

--- a/config/core_set_op_mode.yaml
+++ b/config/core_set_op_mode.yaml
@@ -1,0 +1,21 @@
+# An example command for setting the operation
+# mode of an instrument.
+--- !Command
+name:      CORE_SET_OP_MODE
+opcode:    0x0006
+subsystem: CORE
+desc:      |
+  This command sets the operational mode.
+
+arguments:
+  - !Argument
+    name:  mode
+    desc:  Mode
+    units: none
+    type:  U8
+    bytes: 0
+    enum:
+      0: SAFE
+      1: IDLE
+      2: SCANNING
+      3: SCIENCE


### PR DESCRIPTION
* Created additional command yaml file `core_set_op_mode.yaml` - command was copied from [AIT-Core Users Guide](https://ait-core.readthedocs.io/en/latest/command_intro.html)
* Updated `cmd_schema.json` and `cmd.py` to add `!include` capability

FYI, below is the `ait-yaml-validate --cmd`, `Cmd.encode()`, and `Cmd.decode()` outputs:
![Screen Shot 2019-09-08 at 4 54 40 AM](https://user-images.githubusercontent.com/11483503/64487968-7d8c0880-d1f6-11e9-8724-7142658be082.png)
