### PR TITLE
Issue #204 - Create a standalone OpenMCT plugin

### DIFF
--- a/ait/core/server/plugins/openmct.py
+++ b/ait/core/server/plugins/openmct.py
@@ -1,0 +1,606 @@
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+# Bespoke Link to Instruments and Small Satellites (BLISS)
+#
+# Copyright 2019, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.
+
+"""
+AIT Plugin for OpenMCT Telemetry service
+
+The ait.core.servers.plugins.openmct module provides an
+a web service that implements the service API for the OpenMCT
+framework for realtime and, eventually, historial telemetry
+from AIT.
+"""
+
+import gevent
+import gevent.event
+import gevent.util
+import gevent.lock
+import gevent.monkey
+
+gevent.monkey.patch_all()
+import geventwebsocket
+
+import bdb
+from collections import defaultdict
+import cPickle as pickle
+import importlib
+import json
+import os
+import struct
+import sys
+import time
+import urllib
+import webbrowser
+import re
+
+
+import datetime
+import random
+import time
+
+import bottle
+import pkg_resources
+
+import ait.core
+from ait.core import api, cmd, dmc, dtype, evr, limits, log, notify, pcap, tlm, gds, util
+from ait.core.server.plugin import Plugin
+
+
+class AITOpenMctPlugin(Plugin):
+    """This is the implementation of the AIT plugin for interaction with
+     OpenMCT framework.  Telemetry dispatched from AIT server/broker
+     is passed along to OpenMct in the expected format.
+    """
+
+    # Some class variables
+    DEFAULT_PORT = 8082
+    DEFAULT_DEBUG = False
+
+    def __init__(self, inputs, outputs, zmq_args=None, **kwargs):
+        """
+        Params:
+            inputs:     names of inbound streams plugin receives data from
+            outputs:    names of outbound streams plugin sends its data to
+            zmq_args:   dict containing the follow keys:
+                            zmq_context
+                            zmq_proxy_xsub_url
+                            zmq_proxy_xpub_url
+                        Defaults to empty dict. Default values
+                        assigned during instantiation of parent class.
+            **kwargs:   (optional) Dependent on requirements of child class.
+        """
+
+        super(AITOpenMctPlugin, self).__init__(inputs, outputs, zmq_args, **kwargs)
+
+        log.info('Running AIT OpenMCT Plugin')
+
+        # Initialize state fields
+        # Debug state fields
+        self._debugEnabled = AITOpenMctPlugin.DEFAULT_DEBUG
+        self._debugMimicRepeat = False
+        # Port value for the server
+        self._servicePort = AITOpenMctPlugin.DEFAULT_PORT
+
+
+        # Setup server state
+        self._app = bottle.Bottle()
+        self._servers = []
+
+        # Queues for AIT events events
+        self._tlmQueue = api.GeventDeque(maxlen=100)
+        self._logQueue = api.GeventDeque(maxlen=100)
+
+        # Load AIT tlm dict and create OpenMCT format of it
+        self._aitTlmDict = tlm.getDefaultDict()
+        self._mctTlmDict = self.format_tlmdict_for_openmct(self._aitTlmDict)
+
+        # Create lookup from packet-uid to packet def
+        self._uidToPktDefMap = self.create_uid_pkt_map(self._aitTlmDict)
+
+        # Check for AIT config overrides
+        self._checkConfig()
+
+        # Create and start Greenlet
+        gevent.spawn(self.init)
+
+    def _checkConfig(self):
+        """Check AIT configuration for override values"""
+
+        # Check if debug flag was included
+        if hasattr(self, "debug"):
+            self._debugEnabled = self.debug in ['true', '1', 'TRUE', 'enabled', 'ENABLED']
+            self.dbg_message("Debug flag = " + str(self._debugEnabled))
+
+        # Check if port is assigned
+        if hasattr(self, "port"):
+            try:
+                self._servicePort = int(self.port)
+            except ValueError:
+                self._servicePort = DEFAULT_PORT
+            self.dbg_message("Port = " + str(self._servicePort))
+
+
+    def process(self, input_data, topic=None):
+        # msg is going to be a tuple from the ait_packet_handler
+        # (packet_uid, packet)
+        # need to handle log/telem messages differently based on topic
+        # Look for topic in list of stream log and telem stream names first.
+        # If those lists don't exist or topic not in them, try matching text
+        # in topic name.
+
+        processed = False
+
+        if not processed:
+            if "telem_stream" in topic:
+                self.process_telem_msg(input_data)
+                processed = True
+
+            elif topic == "log_stream":
+                self.process_log_msg(input_data)
+                processed = True
+
+        if not processed:
+            raise ValueError('Topic of received message not recognized as telem or log stream.')
+
+    def process_telem_msg(self, msg):
+        msg = pickle.loads(msg)
+
+        # This will help with debugging
+        uid = msg[0]
+        packet = msg[1]
+
+        #Package as a tuple, then add to queue
+        tlm_entry = (uid, packet)
+        self._tlmQueue.append(tlm_entry)
+
+    def process_log_msg(self, msg):
+        if False:
+            parsed_msg = log.parseSyslog(msg)
+            self._logQueue.append(parsed_msg)
+        else:
+            pass
+
+    # We report our special debug messages on the 'Info' log level
+    # so we dont have to turn on DEBUG logging globally
+    def dbg_message(self, msg):
+        if self._debugEnabled:
+            log.info('AitOpenMctPlugin: ' + msg)
+
+    @staticmethod
+    def datetime_jsonifier(obj):
+        """Required for JSONifying datetime objects"""
+        if isinstance(obj, datetime.datetime):
+            return obj.isoformat()
+        else:
+            return None
+
+    @staticmethod
+    def get_browser_name(browser):
+        return getattr(browser, 'name', getattr(browser, '_name', '(none)'))
+
+    def _get_tlm_packet_def(self, uid):
+        """Return packet definition based on packet unique id"""
+        pkt_defn = self._uidToPktDefMap[uid]
+        return pkt_defn
+
+    def init(self):
+        """Initialize the web-server state"""
+
+        self._route()
+
+        # if host is None:
+        #     host = 'localhost'
+
+        wsgi_server = gevent.pywsgi.WSGIServer(('0.0.0.0', self._servicePort), self._app,
+                      handler_class = geventwebsocket.handler.WebSocketHandler)
+
+        self._servers.append(wsgi_server)
+
+        # Start the servers
+        for s in self._servers:
+            s.start()
+
+    def cleanup(self):
+        """Clean-up the webservers"""
+        for s in self._servers:
+            s.stop()
+
+        #gevent.killall(self._Greenlets)
+
+    def start_browser(self, url, name=None):
+        browser = None
+
+        if name is not None and name.lower() == 'none':
+            log.info('Will not start any browser since --browser=none')
+            return
+
+        try:
+            browser = webbrowser.get(name)
+        except webbrowser.Error:
+            old     = name or 'default'
+            msg     = 'Could not find browser: %s.  Will use: %s.'
+            browser = webbrowser.get()
+            log.warn(msg, name, self.getBrowserName(browser))
+
+        if type(browser) is webbrowser.GenericBrowser:
+            msg = 'Will not start text-based browser: %s.'
+            log.info(msg % self.getBrowserName(browser))
+        elif browser is not None:
+            log.info('Starting browser: %s' % self.getBrowserName(browser))
+            browser.open_new(url)
+
+
+
+    def wait(self):
+        # if len(self._Greenlets) > 0:
+        #     done = gevent.joinall(self._Greenlets, raise_error=True, count=1)
+        #     for d in done:
+        #         if issubclass(type(d.value), KeyboardInterrupt):
+        #             raise d.value
+        # else:
+        gevent.wait()
+
+    @staticmethod
+    def create_uid_pkt_map(aitDict):
+        """Creates a dictionary from packet def UID to package definition"""
+        uid_map = dict()  # type: defaultdict
+        for k, v in aitDict.iteritems():
+            uid_map[v.uid] = v
+        return uid_map
+
+
+    def format_tlmpkt_for_openmct(self, ait_pkt):
+        """Formats an AIT telemetry packet instance as an
+        OpenMCT telemetry packet structure"""
+
+        mct_dict = dict()  # type: defaultdict
+        ait_pkt_def = ait_pkt._defn
+        ait_pkt_id  = ait_pkt_def.name
+
+        mct_pkt_value_dict = dict()  # type: defaultdict
+
+        mct_dict['packet'] = ait_pkt_id
+        mct_dict['data'] = mct_pkt_value_dict
+
+        ait_pkt_fieldmap = ait_pkt_def.fieldmap
+        for ait_field_id in ait_pkt_fieldmap:
+            ait_field_def = ait_pkt_fieldmap[ait_field_id]
+            tlm_pt_id = ait_field_id
+            tlm_pt_value = getattr(ait_pkt, ait_field_id)
+            mct_pkt_value_dict[ait_field_id] = tlm_pt_value
+
+        return mct_dict
+
+    def format_tlmdict_for_openmct(self, ait_tlm_dict):
+        """Formats the AIT telemetry dictionary as an
+        OpenMCT telemetry dictionary"""
+
+        mct_dict = dict()  # type: defaultdict
+        mct_dict['name'] = 'AIT Telemetry'
+        mct_dict['key'] = 'ait_telemetry_dictionary'
+        mct_dict['measurements'] = []  #empty list
+
+        for ait_pkt_id in ait_tlm_dict:
+            ait_pkt_def = ait_tlm_dict[ait_pkt_id]
+            ait_pkt_fieldmap = ait_pkt_def.fieldmap
+            for ait_field_id in ait_pkt_fieldmap:
+                ait_field_def = ait_pkt_fieldmap[ait_field_id]
+
+                mct_field_dict = dict()
+                mct_field_dict['key'] = ait_pkt_id + "." + ait_field_id
+                mct_field_dict['name'] = ait_field_def.name
+                mct_field_dict['name'] = ait_pkt_id + ":" + ait_field_def.name
+
+                # Create a new field value list
+                mct_field_value_list = []
+
+                # Convert AIT field def info to MCT field map
+                mct_field_val_range = self.create_mct_fieldmap(ait_field_def)
+
+                mct_field_val_domain = {
+                        "key": "utc",
+                        "source": "timestamp",
+                        "name": "Timestamp",
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        }
+                    }
+
+                mct_field_value_list.append(mct_field_val_range)
+                mct_field_value_list.append(mct_field_val_domain)
+
+                mct_field_dict['values'] = mct_field_value_list
+
+                mct_dict['measurements'].append(mct_field_dict)
+
+        return mct_dict
+
+    def create_mct_fieldmap(self, ait_pkt_fld_def):
+        """Constructs an OpenMCT field declaration struct from an AIT packet definition"""
+        mct_field_map = {
+            "key": "value",
+            "name": "Value",
+            "hints": {
+                "range": 1
+            }
+        }
+
+        # Handle units
+        if hasattr(ait_pkt_fld_def, 'units'):
+            if ait_pkt_fld_def.units is not None :
+                mct_field_map['units'] = ait_pkt_fld_def.units
+
+        # Type and min/max
+        # Borrowed code from AIT dtype to infer info form type-NAME
+        if hasattr(ait_pkt_fld_def, 'type') :
+            if ait_pkt_fld_def.type is not None:
+                ttype = ait_pkt_fld_def.type
+
+                typename = ttype.name
+
+                tformat = dtype.PrimitiveTypeFormats.get(typename, None)
+                tendian = None
+                tfloat = False
+                tmin = None
+                tmax = None
+                tsigned = False
+                tstring = False
+                tnbits = 0
+
+                if typename.startswith("LSB_") or typename.startswith("MSB_"):
+                    tendian = typename[0:3]
+                    tsigned = typename[4] != "U"
+                    tfloat = typename[4] == "F" or typename[4] == "D"
+                    tnbits = int(typename[-2:])
+                elif typename.startswith("S"):
+                    tformat = typename[1:] + "s"
+                    tnbits = int(typename[1:]) * 8
+                    tstring = True
+                else:
+                    tsigned = typename[0] != "U"
+                    tnbits = int(typename[-1:])
+
+                tnbytes = tnbits / 8
+
+                if tfloat:
+                    tmax = +sys.float_info.max
+                    tmin = -sys.float_info.max
+                elif tsigned:
+                    tmax = 2 ** (tnbits - 1)
+                    tmin = -1 * (tmax - 1)
+                elif not tstring:
+                    tmax = 2 ** tnbits - 1
+                    tmin = 0
+
+                if not tmin is None:
+                    mct_field_map['min'] = tmin
+                if not tmax is None:
+                    mct_field_map['max'] = tmax
+
+                if tfloat:
+                    mct_field_map['format'] = 'float'
+                elif tstring:
+                    mct_field_map['format'] = 'string'
+                else:
+                    mct_field_map['format'] = 'integer'
+
+                ## TODO - handle array types?
+
+        # Handle enumerations
+        if hasattr(ait_pkt_fld_def, 'enum'):
+            if ait_pkt_fld_def.enum is not None:
+                del mct_field_map['min']
+                del mct_field_map['max']
+                mct_field_map['format'] = 'enum'
+                mct_enum_array = []
+                enum_dict = ait_pkt_fld_def.enum
+                for eNumber in enum_dict:
+                    eName = enum_dict.get(eNumber)
+                    enum_entry = { "string": eName, "value": eNumber }
+                    mct_enum_array.append(enum_entry)
+                mct_field_map['enumerations'] = mct_enum_array
+
+        return mct_field_map
+
+    # ---------------------------------------------------------------------
+
+    # Section of methods to which bottle requests will be routed
+
+    def _cors_headers_hook(self):
+        """After-request hook to set CORS response headers."""
+        headers = bottle.response.headers
+        headers['Access-Control-Allow-Origin'] = '*'
+        headers['Access-Control-Allow-Methods'] = 'PUT, GET, POST, DELETE, OPTIONS'
+        headers['Access-Control-Allow-Headers'] = 'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token'
+
+
+
+    def get_tlm_dict_json(self):
+        """Returns the OpenMCT-formatted dictionary"""
+        return json.dumps(self._mctTlmDict)
+
+    def get_tlm_dict_raw_json(self):
+        """Returns the AIT-formatted dictionary"""
+        return json.dumps(self._aitTlmDict.toJSON())
+
+    def get_realtime_tlm(self):
+        """Handles realtime packet dispatch via websocket layers"""
+        pad = bytearray(1)
+        websocket = bottle.request.environ.get('wsgi.websocket')
+
+        if not websocket:
+            bottle.abort(400, 'Expected WebSocket request.')
+
+        empty_map = dict()  # default empty object to JSON and send
+
+        req_env = bottle.request.environ
+        client_ip = req_env.get('HTTP_X_FORWARDED_FOR') or req_env.get('REMOTE_ADDR') or "(unknown)"
+        self.dbg_message('Creating a new web-socket session with client IP '+client_ip)
+
+        try:
+            while not websocket.closed:
+                try:
+                    self.dbg_message("Polling Telemtry queue...")
+                    uid, data = self._tlmQueue.popleft(timeout=30)
+                    pkt_defn = self._get_tlm_packet_def(uid)
+                    if not pkt_defn:
+                        continue
+
+                    pkt_name = pkt_defn.name
+
+                    ait_pkt = ait.core.tlm.Packet(pkt_defn, data=data)
+
+                    openmct_pkt = self.format_tlmpkt_for_openmct(ait_pkt)
+
+                    openmct_pkt_jsonstr = json.dumps(openmct_pkt, default=self.datetime_jsonifier)
+
+                    self.dbg_message("Sending realtime telemtry websocket msg: "+openmct_pkt_jsonstr)
+
+                    websocket.send(openmct_pkt_jsonstr)
+
+                except IndexError:
+                    # If no telemetry has been received by the GUI
+                    # server after timeout seconds, "probe" the client
+                    # websocket connection to make sure it's still
+                    # active and if so, keep it alive.  This is
+                    # accomplished by sending a packet with an ID of
+                    # zero and no packet data.  Packet ID zero with no
+                    # data is ignored by AIT GUI client-side
+                    # Javascript code.
+
+                    self.dbg_message("Telemtry queue is empty.")
+
+
+                    #websocket.send("log: No new telem products to report")
+
+
+                    if not websocket.closed:
+                        websocket.send(json.dumps(empty_map))
+                        #websocket.send(pad + struct.pack('>I', 0))
+
+            self.dbg_message('Web-socket session closed with client IP '+client_ip)
+
+        except geventwebsocket.WebSocketError, wser:
+            log.warn('Web-socket session had an error with client IP '+client_ip+': '+str(wser))
+            pass
+
+    def get_historical_tlm(self, mct_pkt_id):
+        """(Non-)handling of historial queries"""
+        startParam = bottle.request.query.start
+        endParam   = bottle.request.query.end
+        # At some point we may support this query, but not for now...
+        empty_dict = dict()
+        return json.dumps(empty_dict)
+
+
+    def mimic_tlm(self, ait_tlm_pkt_name, ait_tlm_pkt_fill=None):
+        """Used for debugging, creates an instance of a packet based on
+        packet name, and fills it with zero data.
+        Special case for '1553_HS_Packet' which will get random number
+        data fills.
+        If HTTP Request query includes a value for 'repeat', then this
+        will continue emitting telemetry.
+        """
+
+        # Http query option, if it is set to anything, consider it true
+        self._debugMimicRepeat = len(str(bottle.request.query.repeat)) > 0
+
+        # This will be helpful in testing by simulating TLM
+        # but by a rest call instead of actual telem
+        ait_pkt_defn = None
+        if ait_tlm_pkt_name:
+            ait_pkt_defn = tlm.getDefaultDict()[ait_tlm_pkt_name]
+        else:
+            ait_pkt_defn = tlm.getDefaultDict().values()[0]
+
+        # Create the expected message format
+        pkt_def_uid = ait_pkt_defn.uid
+        pkt_size_bytes = ait_pkt_defn.nbytes
+
+        #if self._debugMimicRepeat:
+        repeatStr = " REPEATED " if self._debugMimicRepeat else " a single "
+        info_msg = "Received request to mimic"+repeatStr+"telemetry packet for " + ait_pkt_defn.name
+        self.dbg_message(info_msg)
+
+        # Create a binary array of size filled with 0
+        dummy_data = bytearray(pkt_size_bytes)
+
+        info_msg = ""
+
+        while True:
+
+            # Special handling for simply integer based packet, others will
+            # have all 0 zero
+            if ait_pkt_defn.name == '1553_HS_Packet':
+                hs_packet = struct.Struct('>hhhhh')
+                randomNum = random.randint(1,100)
+                dummy_data = hs_packet.pack(randomNum,randomNum,randomNum,randomNum,randomNum)
+
+            msg_serial = pickle.dumps((pkt_def_uid, dummy_data), 2)
+            self.process_telem_msg(msg_serial)
+
+            info_msg = "AIT OpenMct Plugin submitted mimicked telemetry for " + ait_pkt_defn.name + " (" + str(datetime.datetime.now()) + ")"
+            self.dbg_message(info_msg)
+
+            # sleep if mimic on
+            if self._debugMimicRepeat:
+                time.sleep(5)
+
+            # either it was immediate or we woke up, check break condition
+            if not self._debugMimicRepeat:
+                break
+
+        # Return last status message as result to client
+        return info_msg
+
+
+    # ---------------------------------------------------------------------
+
+    # Routing rules
+
+    def _route(self):
+        """Performs the Bottle app routing"""
+
+        # Returns OpenMCT formatted tlm dict
+        self._app.route('/tlm/dict',     callback=self.get_tlm_dict_json)
+
+        # Returns AIT formatted tlm dict
+        self._app.route('/tlm/dict/raw', callback=self.get_tlm_dict_raw_json)
+
+        # Estasblished websocket for realtime tlm packets
+        self._app.route('/tlm/realtime', callback=self.get_realtime_tlm)
+
+        # Http: tlm query for a given time range
+        self._app.route('/tlm/history/<mct_pkt_id>', callback=self.get_historical_tlm)
+
+        # Enable CORS via headers
+        self._app.add_hook('after_request', self._cors_headers_hook)
+
+        # Debugging routes
+        if (self._debugEnabled):
+            self._app.route('/tlm/debug/sim/<ait_tlm_pkt_name>', callback=self.mimic_tlm)
+
+        # self._App.route('/<pathname:path>', callback=self.get_static_file)
+
+
+        # Was in the original impl, but not sure we need it.  Don't want to lose
+        # it completely tho, just in case.
+        # def __setResponseToEventStream():
+        #     bottle.response.content_type  = 'text/event-stream'
+        #     bottle.response.cache_control = 'no-cache'
+        #
+        # def __setResponseToJSON():
+        #     bottle.response.content_type  = 'application/json'
+        #     bottle.response.cache_control = 'no-cache'
+

--- a/doc/source/ait.core.server.plugins.openmct.rst
+++ b/doc/source/ait.core.server.plugins.openmct.rst
@@ -1,0 +1,7 @@
+ait.core.server.plugins.openmct module
+======================================
+
+.. automodule:: ait.core.server.plugins.openmct
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/ait.core.server.plugins.rst
+++ b/doc/source/ait.core.server.plugins.rst
@@ -6,7 +6,7 @@ Submodules
 
 .. toctree::
 
-   ait.core.server.plugins.ait_gui_plugin
+   ait.core.server.plugins.openmct
 
 Module contents
 ---------------

--- a/doc/source/ait.core.server.rst
+++ b/doc/source/ait.core.server.rst
@@ -6,6 +6,7 @@ Subpackages
 
 .. toctree::
 
+    ait.core.server.plugins
     ait.core.server.test
 
 Submodules

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -25,6 +25,7 @@ Visit the :doc:`Installation and Environment Configuration <installation>` guide
    Extensions <extensions>
    Command & Data Handling Tables <c_and_dh_intro>
    bsc_intro
+   plugin_openmct
 
 Indices and tables
 ==================

--- a/doc/source/plugin_openmct.rst
+++ b/doc/source/plugin_openmct.rst
@@ -1,0 +1,102 @@
+AIT OpenMCT Plugin
+========================
+
+The 'openmct' directory (AIT-Core/openmct/) contains files needed by your
+OpenMCT installation that will expose AIT realtime and historical telemetry
+endpoints to the OpenMCT framework.
+
+There is a two step process:
+
+* Activate the OpenMCT plugin within the AIT server configuration.  This step creates the data source from which OpenMCT will pull data.
+
+* Integrate AIT extensions in OpenMCT.  This step installs Javascript extensions into the OpenMCT framework that will access the AIT OpenMCT plugin service.
+
+
+.. _Ait_openmct_plugin:
+
+Activating the OpenMCT Plugin
+-----------------------------
+
+Update your AIT configuration file :ref:`config.yaml <Config_Intro>` to add the AITOpenMctPlugin in the 'server:plugins:' section.
+
+.. _Ait_openmct_port:
+The plugin's 'port' value defaults to 8082, but can be overridden in the configuration.  If something other than the default is used, you will also need to include this in
+the OpenMCT frameworks's setup configuration.
+
+Currently, the server is assumed to run on 'localhost'.
+
+.. _Plugin_config:
+
+Example configuration:
+
+.. code-block:: none
+
+    plugins:
+        - plugin:
+            name: ait.core.server.plugins.openmct.AITOpenMctPlugin
+            inputs:
+                - log_stream
+                - telem_stream
+            port: 8082
+
+
+
+Integrating with OpenMCT Framework
+----------------------------------
+
+**Note:**
+The AIT extension requires 'http.js', a library that was included in the OpenMCT Tutorial (Apache License, Version 2.0).
+The source location of this file is: https://github.com/nasa/openmct-tutorial/tree/completed/lib/http.js
+
+Setup
+^^^^^
+
+1. Install OpenMCT (https://nasa.github.io/openmct/getting-started/)
+We will assume that OpenMCT is installed in a directory referenced
+by the environment variable ${OPENMCT_DIR}
+
+
+2. Copy the downloaded 'http.js' library file to your OpenMCT installation:
+
+.. code-block:: none
+
+    mkdir ${OPENMCT_DIR}/lib
+    cp http.js ${OPENMCT_DIR}/lib/
+
+
+3. Copy the 'ait_integration.js' file to your OpenMCT installation:
+
+.. code-block:: none
+
+    cp ait_integration.js ${OPENMCT_DIR}
+
+
+4. Edit the existing OpenMCT 'index.html' file to include references to the 'http.js' and 'ait_integration.js' (prior
+to the script tag that initializes OpenMCT):
+
+.. code-block:: none
+
+        <script src="lib/http.js"></script>
+        <script src="ait_integration.js"></script>
+
+
+5. Install AIT extensions to the openmct framework (prior to the openmct.start() function call).  Value of 'port' should match the value used in the :ref:`previous section<Ait_openmct_plugin>`.
+
+.. code-block:: none
+
+        openmct.install(AITIntegration({
+                host: 'localhost',
+                port : 8082 }));
+        openmct.install(AITHistoricalTelemetryPlugin());
+        openmct.install(AITRealtimeTelemetryPlugin());
+
+
+
+
+Running AIT / OpenMCT
+---------------------
+
+1) Start the AIT server (configured to run AIT's OpenMct plugin)
+2) Start OpenMCT server.
+3) Open browser to location of the OpenMCT UI endpoint.
+

--- a/openmct/README
+++ b/openmct/README
@@ -1,0 +1,69 @@
+This directory contains files need by your OpenMCT installation that
+will expose AIT realtime and historical telemetry endpoints to the
+OpenMCT framework.
+
+------------------------
+
+Notes:
+
+- It is assumed that the AitOpenMctPlugin has been activated in the AIT
+server configuration file, as this provides the sources for telemetry.
+See the local file 'ait_cfg_section.yaml' for the expected section to 
+be added to your $AIT_CONFIG file.
+
+- For this guide, we also assume that the AIT server is running on 
+host 'localhost' and port 8082, which are two configuration options
+that can be passed to the OpenMct AIT extension during
+session setup.
+
+- The AIT extension requires 'http.js', a library that was
+included in the OpenMCT Tutorial (Apache License, Version 2.0).
+The source location of this file is: 
+https://github.com/nasa/openmct-tutorial/tree/completed/lib/http.js  
+
+------------------------
+
+Setup:
+
+1) Install OpenMCT (https://nasa.github.io/openmct/getting-started/)
+We will assume that OpenMCT is installed in a directory referenced
+by the environment variable ${OPENMCT_DIR}
+
+
+2) Copy the downloaded 'http.js' library file to your OpenMCT installation:
+
+> mkdir ${OPENMCT_DIR}/lib
+> cp http.js ${OPENMCT_DIR}/lib/
+
+
+3) Copy the 'ait_integration.js' file to your OpenMCT installation:
+
+> cp ait_integration.js ${OPENMCT_DIR}
+
+
+4) Edit the existing OpenMCT 'index.html' file to include
+references to the 'http.js' and 'ait_integration.js' (prior
+to the script tag that initializes OpenMCT):
+
+        <script src="lib/http.js"></script> 
+        <script src="ait_integration.js"></script>
+
+ 
+5) Install AIT extensions to the openmct framework (prior
+to the openmct.start() function call):
+
+         openmct.install(AITIntegration({
+                 host: 'localhost',
+                 port : 8082 })); 
+         openmct.install(AITHistoricalTelemetryPlugin());
+         openmct.install(AITRealtimeTelemetryPlugin());
+ 
+ 
+--------------------------
+
+Running:
+
+1) Start the AIT server (configured to run AIT's OpenMct plugin)
+2) Start OpenMCT server.
+3) Open browser to location of the OpenMCT UI endpoint.
+

--- a/openmct/ait_cfg_section.yaml
+++ b/openmct/ait_cfg_section.yaml
@@ -1,0 +1,14 @@
+# Copy-paste the non-commented out section of YAML to install 
+# the AIT OpenMCT plugin for your server
+# Port default is 8082, ensure this matches the AIT integration config
+# in OpenMCT's index.html.
+
+//default:
+//    server:
+          plugins:
+            - plugin:
+                name: ait.core.server.plugins.openmct.AITOpenMctPlugin
+                inputs:
+                    - log_stream
+                    - telem_stream
+                port: 8082

--- a/openmct/ait_integration.js
+++ b/openmct/ait_integration.js
@@ -1,0 +1,338 @@
+/*
+ * Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+ * Bespoke Link to Instruments and Small Satellites (BLISS)
+ *
+ * Copyright 2019, by the California Institute of Technology. ALL RIGHTS
+ * RESERVED. United States Government Sponsorship acknowledged. Any
+ * commercial use must be negotiated with the Office of Technology Transfer
+ * at the California Institute of Technology.
+ *
+ * This software may be subject to U.S. export control laws. By accepting
+ * this software, the user agrees to comply with all applicable U.S. export
+ * laws and regulations. User has the responsibility to obtain export licenses,
+ * or other export authority as may be required before exporting such
+ * information to foreign countries or providing access to foreign persons.
+ */
+
+/*
+ * Example functions for AIT integration with OpenMCT. The below code can be
+ * used in place of the examples provided in the OpenMCT Tutorial so that
+ * AIT telemetry can be viewed in real time.
+ *
+ * https://github.com/nasa/openmct-tutorial
+ *
+ * Important Notes and Setup:
+ *  - The current AIT backend implementation does not support the OpenMCT
+ *    historical data query implementation. To work around this, ensure
+ *    that the historical data endpoint in OpenMCT returns an empty
+ *    dataset for any queried point. The AITHistoricalTelemetryPlugin
+ *    function calls the default OpenMCT Tutorial historical endpoint.
+ *  - Include the below code into OpenMCT by including this file in the
+ *    example index.html file and installing the various components.
+ *
+ *    <script src="ait_integration.js"></script>
+ *
+ *
+ *    openmct.install(AITIntegration(aitconfig));
+ *    openmct.install(AITHistoricalTelemetryPlugin());
+ *    openmct.install(AITRealtimeTelemetryPlugin());
+ *
+ *  - where 'aitconfig' is a JSON dictionary that can contain overrides
+ *    for AIT Host ('host'), or AIT Port ('port'), e.g.
+ *
+ *      aitconfig = {  'host': 'localhost', 'port': 8082 };
+ *
+ *    or a subset, where default values will be used.
+ *
+ * How to run:
+ *  Assuming the above "Important Notes and Setup" have been handled and
+ *  the installation instructions in the OpenMCT Tutorial have been run:
+ *
+ *  1) Run `ait-server.py` to start the AIT backend server
+ *  2) Run `npm start` to run the OpenMCT server
+ *  3) Point your browser to localhost:8080
+ */
+
+//DEFAULTS
+// AIT connection settings
+const AIT_HOST_DEFAULT = 'localhost';
+const AIT_PORT_DEFAULT = 8082;
+//Debug
+const DEBUG_ENABLED_DEFAULT = false;
+
+// State variables for connections, debug, ws-reconnect
+let ait_host  = AIT_HOST_DEFAULT;
+let ait_post  = AIT_PORT_DEFAULT;
+let ait_debug = DEBUG_ENABLED_DEFAULT;
+
+let ws_reconnect_enabled = true;
+let ws_reconnect_wait_millis = 10000;
+
+// Keep a reference to our promise for tlmdict
+let tlmdictPromise = null;
+
+
+//---------------------------------------------
+
+// Updated OpenMCT endpoint returns a converted version of the original AIT
+// telem dict so that OpenMct can ingest it.  As such, we just call http.get
+// on that endpoint and return the resulting promise.
+function getDictionary(host, port) {
+
+    let tdUrl = 'http://' + host + ':' + port + '/tlm/dict'
+    debugMsg("Creating tlmdict promise from "+tdUrl)
+
+    return http.get(tdUrl).then(function (result) {
+           return JSON.parse(result.data)
+    });
+
+}
+
+
+//---------------------------------------------
+
+// Prints debug message to console, only if debug is enabled
+function debugMsg(msg) {
+    if (ait_debug)
+        console.log("OpenMct/AIT: "+msg);
+}
+
+
+//---------------------------------------------
+
+//Sets config, creates providers for Objects and Composition
+//for AIT
+function AITIntegration(config) {
+
+
+    ait_host  = AIT_HOST_DEFAULT;
+    ait_post  = AIT_PORT_DEFAULT;
+    ait_debug = DEBUG_ENABLED_DEFAULT;
+
+    //check for configuration overrides
+    if (config != null)
+    {
+        if (config.hasOwnProperty('debug'))
+        {
+            ait_debug = (config.debug === "true");
+        }
+        if (config.hasOwnProperty('host'))
+        {
+            ait_host = config.host;
+
+        }
+        if (config.hasOwnProperty('port'))
+        {
+            //Really Javascript? Gotta jump through THIS hoop??
+            ait_port = (Number.isInteger(config.port)) ? config.port :
+                       (parseInt(config.port) || AIT_PORT_DEFAULT);
+        }
+    }
+
+    //You will only see these if DEBUG was enabled
+    debugMsg("AIT Debug set to: "+ait_debug);
+    debugMsg("AIT Host  set to: "+ait_host);
+    debugMsg("AIT Port  set to: "+ait_port);
+
+    tlmdictPromise  = getDictionary(ait_host, ait_port);
+
+    let objectProvider = {
+        get: function (identifier) {
+
+            return tlmdictPromise.then(function (dictionary) {
+                if (identifier.key === 'spacecraft') {
+                    return {
+                        identifier: identifier,
+                        name: dictionary.name,
+                        type: 'folder',
+                        location: 'ROOT'
+                    };
+                } else {
+                    let measurement = dictionary.measurements.filter(function (m) {
+                        return m.key === identifier.key;
+                    })[0];
+                    return {
+                        identifier: identifier,
+                        name: measurement.name,
+                        type: 'telemetry',
+                        telemetry: {
+                            values: measurement.values
+                        },
+                        location: 'taxonomy:spacecraft'
+                    };
+                }
+            });
+        }
+    };
+
+    let compositionProvider = {
+        appliesTo: function (domainObject) {
+            return domainObject.identifier.namespace === 'taxonomy' &&
+                   domainObject.type === 'folder';
+        },
+        load: function (domainObject) {
+            return tlmdictPromise
+                .then(function (dictionary) {
+                    return dictionary.measurements.map(function (m) {
+                        return {
+                            namespace: 'taxonomy',
+                            key: m.key
+                        };
+                    });
+                });
+        } //,
+        // loadHeirarchy: function (domainObject) {
+        //     return tlmdictPromise
+        //         .then(function (dictionary) {
+        //             domainObject.identifier.key
+        //             function checkParent(age) {
+        //                 return age >= 18;
+        //             }
+        //             return dictionary.measurements.map(function (m) {
+        //                 return {
+        //                     namespace: 'taxonomy',
+        //                     key: m.key
+        //                 };
+        //             });
+        //         });
+        // }
+    };
+
+    return function install(openmct) {
+        openmct.objects.addRoot({
+            namespace: 'taxonomy',
+            key: 'spacecraft'
+        });
+    
+        openmct.objects.addProvider('taxonomy', objectProvider);
+    
+        openmct.composition.addProvider(compositionProvider);
+    
+        openmct.types.addType('telemetry', {
+            name: 'Telemetry Point',
+            description: 'Spacecraft Telemetry point',
+            cssClass: 'icon-telemetry'
+        });
+    };
+}
+
+//---------------------------------------------
+
+//Historical telemetry
+function AITHistoricalTelemetryPlugin() {
+
+    const historicalQueryEnabled = false;
+
+    return function install (openmct) {
+        let provider = {
+            supportsRequest: function (domainObject) {
+                return domainObject.type === 'telemetry';
+            },
+            request: function (domainObject, options) {
+                let histUrlRoot = 'http://' + ait_host + ':' + ait_port + '/tlm/history/'
+                let histUrl = histUrlRoot + domainObject.identifier.key +
+                    '?start=' + options.start + '&end=' + options.end;
+    
+                return http.get(histUrl)
+                    .then(function (resp) {
+                        return resp.data
+                    });
+            }
+        };
+    
+        openmct.telemetry.addProvider(provider);
+    }
+}
+
+
+//---------------------------------------------
+
+//setup for realtime handling, via websockets
+
+let realtimeListeners = {};
+
+//Creates a new websocket to the AIT service.
+//This will optionally attempt reconnect upon socket close
+let connectRealtime = function()
+{
+    let socketUrl = 'ws://' + ait_host + ':' + ait_port + '/tlm/realtime';
+
+    debugMsg("Creating new realtime Websocket!");
+    let web_socket = new WebSocket(socketUrl);
+
+    web_socket.onmessage = function (event) {
+
+        let now = Date.now();
+        let listener = realtimeListeners;
+
+        //support passing log messages
+        if (Object.prototype.toString.call(event) === "[object String]" && event.startsWith("log")) {
+            debugMsg("WebSocket log message: " + str(event));
+            return;
+        }
+
+        let msg_json = JSON.parse(event.data)
+
+        //Check that JSON object contains telemetry info
+        if (msg_json.hasOwnProperty('packet') &&
+            msg_json.hasOwnProperty('data')) {
+            let packet = msg_json.packet;
+            let data   = msg_json.data;
+            for (let p in data) {
+                let point = {
+                    'id': packet + '.' + p,
+                    'timestamp': now,
+                    'value': data[p]
+                };
+
+                //Broadcast telemetry point to associated listener
+                if (listener[point.id]) {
+                    debugMsg("Broadcasting realtime telem event for '" + JSON.stringify(point));
+                    listener[point.id](point);
+                }
+            }
+        }
+    };
+
+    web_socket.onerror = function (event) {
+        console.warn("AIT realtime Websocket error: "+JSON.stringify(event))
+    };
+
+    web_socket.onclose = function (event) {
+        debugMsg("AIT realtime Websocket closed: "+JSON.stringify(event));
+        if (ws_reconnect_enabled) {
+            debugMsg("AIT realtime Websocket will attempt reconnect after "+ws_reconnect_wait_millis+" ms");
+            setTimeout(connectRealtime, ws_reconnect_wait_millis)
+        }
+    };
+
+    return web_socket;
+};
+
+//Realtime Telemetry
+function AITRealtimeTelemetryPlugin() {
+
+    return function install(openmct) {
+
+        //attach to listener map declared above
+        let listener = realtimeListeners;
+
+        connectRealtime();
+
+        let provider = {
+            supportsSubscribe: function (domainObject) {
+                return domainObject.type === 'telemetry';
+            },
+            subscribe: function (domainObject, callback) {
+                debugMsg("Adding realtime subscriber for key "+domainObject.identifier.key);
+                listener[domainObject.identifier.key] = callback;
+                return function unsubscribe() {
+                    debugMsg("Removing realtime subscriber for key "+domainObject.identifier.key);
+                    delete listener[domainObject.identifier.key];
+                };
+            }
+        };
+
+        openmct.telemetry.addProvider(provider);
+    };
+};


### PR DESCRIPTION
This PR introduces:
1) new standalone OpenMct plugin (residing under ait/core/server/plugins), which provides OpenMCT formatted results;
2) modified ait_integration.js  (originally in AIT-GUI repo), which interacts with the plugin;
3) Documentation for a user to perform the integration into OpenMct deployment.

Resolve #204 