### PR TITLE
Issue #206 - Fix command duplicate opcode / name validation

### DIFF
--- a/ait/core/cmd.py
+++ b/ait/core/cmd.py
@@ -397,8 +397,19 @@ class CmdDict(dict):
 
     def add(self, defn):
         """Adds the given Command Definition to this Command Dictionary."""
-        self[defn.name]            = defn
-        self.opcodes[defn._opcode] = defn
+        if defn.name not in self:
+            self[defn.name] = defn
+        else:
+            msg = "Duplicate Command name '%s'" % defn.name
+            log.error(msg)
+            raise util.YAMLError(msg)
+
+        if defn._opcode not in self.opcodes:
+            self.opcodes[defn._opcode] = defn
+        else:
+            msg = "Duplicate Command opcode '%s'" % defn._opcode
+            log.error(msg)
+            raise util.YAMLError(msg)
 
 
     def create(self, name, *args, **kwargs):

--- a/ait/core/test/test_val.py
+++ b/ait/core/test/test_val.py
@@ -307,17 +307,17 @@ def testCmdValidator():
     assert v
     assert len(msgs) == 0
 
-    # test failed cmd validation - duplicate name
-    msgs, v = cmdval([os.path.join(DATA_PATH,  "testCmdValidator1.yaml"), cmd.getDefaultSchema()])
-    assert not v
-    assert len(msgs) == 1
-    assert "Duplicate command name" in msgs[0]
+    try:
+        msgs, v = cmdval([os.path.join(DATA_PATH,  "testCmdValidator1.yaml"), cmd.getDefaultSchema()])
+        assert False
+    except util.YAMLError, e:
+        assert "Duplicate Command name" in e.message
 
-    # test failed cmd validation - duplicate opcode
-    msgs, v = cmdval([os.path.join(DATA_PATH,  "testCmdValidator2.yaml"), cmd.getDefaultSchema()])
-    assert not v
-    assert len(msgs) == 2
-    assert "Duplicate opcode" in msgs[1]
+    try:
+        msgs, v = cmdval([os.path.join(DATA_PATH,  "testCmdValidator2.yaml"), cmd.getDefaultSchema()])
+        assert False
+    except util.YAMLError, e:
+        assert "Duplicate Command opcode" in e.message
 
     # test failed cmd validation - bad argtype
     msgs, v = cmdval([os.path.join(DATA_PATH,  "testCmdValidator3.yaml"), cmd.getDefaultSchema()])

--- a/ait/core/test/testdata/val/testCmdValidator1.yaml
+++ b/ait/core/test/testdata/val/testCmdValidator1.yaml
@@ -12,8 +12,7 @@
       units: none
       type:  MSB_U16
       bytes: [0,1]
-
-
+      
 # Following command has same name as the first
 - !Command
   name:      AIT_DUPLICATE_COMMAND

--- a/ait/core/test/testdata/val/testCmdValidator2.yaml
+++ b/ait/core/test/testdata/val/testCmdValidator2.yaml
@@ -1,5 +1,5 @@
 - !Command
-  name:      AIT_DUPLICATE_COMMAND
+  name:      AIT_COMMAND1
   opcode:    0x1001
   subsystem: DCC
   desc:      |
@@ -16,7 +16,7 @@
 
 # Following command has same name as the first
 - !Command
-  name:      AIT_DUPLICATE_COMMAND
+  name:      AIT_COMMAND2
   opcode:    0x1001
   subsystem: CMD
   desc:      |

--- a/ait/core/val.py
+++ b/ait/core/val.py
@@ -32,7 +32,7 @@ import linecache
 import jsonschema
 import collections
 
-from ait.core import dtype, log, tlm, util
+from ait.core import cmd, dtype, log, tlm, util
 
 
 class YAMLProcessor (object):
@@ -427,10 +427,8 @@ class CmdValidator (Validator):
         log.debug("BEGIN: Content-based validation of Command dictionary")
         if ymldata is not None:
             cmddict = ymldata
-        elif ymldata is None and self._ymlproc.loaded:
-            cmddict = self._ymlproc.data
-        elif not self._ymlproc.loaded:
-            raise util.YAMLError("YAML failed to load.")
+        else:
+            cmddict = cmd.CmdDict(self._ymlfile)
 
         try:
             # instantiate the document number. this will increment in order to
@@ -450,10 +448,9 @@ class CmdValidator (Validator):
 
             # set uniqueness rule for opcodes
             rules.append(UniquenessRule('opcode', "Duplicate opcode: %s", messages))
-            #
-            ###
-            for cmdcnt, cmddefn in enumerate(cmddict[0]):
-                # check the command rules
+
+            for key in cmddict.keys():
+                cmddefn = cmddict[key]
                 for rule in rules:
                     rule.check(cmddefn)
 
@@ -630,7 +627,6 @@ class UniquenessRule(ValidationRule):
             self.valid = False
         elif val is not None:
             self.val_list.append(val)
-            log.debug(self.val_list)
 
 
 class TypeRule(ValidationRule):


### PR DESCRIPTION
Update CmdDict.add so duplicate opcodes or command names result in a
raised exception. This mirrors the TlmDict handling.

Update command dicitonary load during validation to create a CmdDict
object instead of loading the YAML "manually." This is necessary to
support included commands

Update command validation checks to handle raised exceptions for
duplicate opcode and command names. Fix error in duplicate opcode test
so commands don't have duplicate names as well.

Resolve #206 