### PR TITLE
Issue #216 and #217 - Fix default plugins and handler package

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -112,7 +112,7 @@ default:
             path: /gds/${phase}/data/${hostname}/%Y/%Y-%j/ats
             
     server:
-        plugins:
+        plugins: []
 
         inbound-streams:
             - stream:
@@ -125,7 +125,7 @@ default:
                 input: 
                     - 3076
                 handlers:
-                    - name: ait.core.server.handler.PacketHandler
+                    - name: ait.core.server.handlers.PacketHandler
                       packet: 1553_HS_Packet
 
         outbound-streams:


### PR DESCRIPTION
Issue #216 - Update server.plugins default value in config to an empty
list so it doesn't fall back to None. This prevents it from breaking
other code that checks if the value exists and falls back to a sane
default if it doesn't.

Issue #217 - Handler class path wasn't updated as part of the changes in
issue #214.

Resolve #216 
Resolve #217 