### PR TITLE
Issue #233 - document Python 3.7 compatibility

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -3,6 +3,8 @@ Installation and Environment Configuration
 
 The following guide will show you how to install and configure AIT Core. For information on how to configure a new project to use AIT, check out the :doc:`New Project Setup <project_setup>` page.
 
+.. note::  AIT is tested against *Python 3.7*.  Running AIT with other versions of *Python 3* may have issues.
+
 Installation
 ------------
 

--- a/doc/source/project_setup.rst
+++ b/doc/source/project_setup.rst
@@ -3,6 +3,8 @@ Setting up a New Project with AIT
 
 The following documentation will teach you how to setup a new project to build off of the AMMOS Instrument Toolkit. This guide assumes that the project you'll be developing is a Python-based project.
 
+.. note::  AIT is tested against *Python 3.7*.  Running AIT with other versions of *Python 3* may have issues.
+
 Add AIT Core as a Dependency
 ------------------------------
 


### PR DESCRIPTION
Added a note about Python 3.7 compatibility as note for 'Installation...' and 'Setting Up...' page.

Resolves #233 