### PR TITLE
Issue #143 - CmdApi utilizes newly added server command entry point

### DIFF
--- a/ait/core/__init__.py
+++ b/ait/core/__init__.py
@@ -26,4 +26,16 @@ def deprecated(message):
   return deprecated_decorator
 
 sys.modules['ait'].deprecated = deprecated
-sys.modules['ait'].DEFAULT_CMD_PORT = 3075
+sys.modules['ait'].DEFAULT_CMD_PORT  = 3075
+sys.modules['ait'].DEFAULT_CMD_HOST  = '127.0.0.1'
+
+## Name of the ZMQ topic used to accept commands from external sources
+sys.modules['ait'].DEFAULT_CMD_TOPIC = '__commands__'
+
+## Number of seconds to sleep after ZmqSocket.connect() call, affects clients
+sys.modules['ait'].DEFAULT_CMD_ZMQ_SLEEP = 1
+
+
+
+sys.modules['ait'].SERVER_DEFAULT_XSUB_URL = "tcp://*:5559"
+sys.modules['ait'].SERVER_DEFAULT_XPUB_URL = "tcp://*:5560"

--- a/ait/core/server/__init__.py
+++ b/ait/core/server/__init__.py
@@ -1,9 +1,5 @@
 import sys
 
-
-sys.modules['ait'].SERVER_DEFAULT_XSUB_URL = "tcp://*:5559"
-sys.modules['ait'].SERVER_DEFAULT_XPUB_URL = "tcp://*:5560"
-
 from .broker import *
 from .server import *
 from .plugin import Plugin

--- a/ait/core/server/client.py
+++ b/ait/core/server/client.py
@@ -83,7 +83,7 @@ class ZMQInputClient(ZMQClient, gevent.Greenlet):
             while True:
                 gevent.sleep(0)
                 topic, message = self.sub.recv_string().split(' ', 1)
-                log.debug('{} recieved message from {}'.format(self, topic))
+                log.debug('{} received message from {}'.format(self, topic))
                 self.process(message, topic=topic)
 
         except Exception as e:
@@ -119,6 +119,7 @@ class PortOutputClient(ZMQInputClient):
         log.debug('Published message from {}'.format(self))
 
 
+
 class PortInputClient(ZMQClient, gs.DatagramServer):
     """
     This is the parent class for all inbound streams which receive messages
@@ -144,5 +145,5 @@ class PortInputClient(ZMQClient, gs.DatagramServer):
 
     def handle(self, packet, address):
         # This function provided for gs.DatagramServer class
-        log.debug('{} recieved message from port {}'.format(self, address))
+        log.debug('{} received message from port {}'.format(self, address))
         self.process(packet)

--- a/ait/core/server/server.py
+++ b/ait/core/server/server.py
@@ -170,8 +170,14 @@ class Server(object):
         stream_input = config.get('input', None)
         stream_output = config.get('output', None)
 
+        stream_cmd_sub = config.get('command-subscriber', None)
+        if stream_cmd_sub:
+            stream_cmd_sub = str(stream_cmd_sub).lower() in ['true', 'enabled', '1']
+
+        ostream = None
+
         if type(stream_output) is int:
-            return PortOutputStream(name,
+            ostream = PortOutputStream(name,
                                     stream_input,
                                     stream_output,
                                     stream_handlers,
@@ -182,12 +188,17 @@ class Server(object):
             if stream_output is not None:
                 log.warn("Output of stream {} is not an integer port. "
                          "Stream outputs can only be ports.".format(name))
-            return ZMQStream(name,
+            ostream = ZMQStream(name,
                              stream_input,
                              stream_handlers,
                              zmq_args={'zmq_context': self.broker.context,
                                        'zmq_proxy_xsub_url': self.broker.XSUB_URL,
                                        'zmq_proxy_xpub_url': self.broker.XPUB_URL})
+
+        #Set the cmd subscriber field for the stream
+        ostream.cmd_subscriber = stream_cmd_sub is True
+
+        return ostream
 
     def _create_handler(self, config):
         """

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -150,12 +150,12 @@ default:
         inbound-streams:
             - stream:
                 name: log_stream
-                input: 
+                input:
                     - 2514
 
             - stream:
                 name: telem_stream
-                input: 
+                input:
                     - 3076
                 handlers:
                     - name: ait.core.server.handlers.PacketHandler
@@ -165,3 +165,4 @@ default:
             - stream:
                 name: command_stream
                 output: 3075
+                command_subscriber: True

--- a/doc/source/server_architecture.rst
+++ b/doc/source/server_architecture.rst
@@ -50,10 +50,13 @@ Streams
 
    - Outbound streams also have the option to **output** to an integer port (see :ref:`example config below <Stream_config>`).
 
+   - The server exposes an entry point for commands submitted by other processes. During initialization, this entry point will be connected to a single outbound stream, either explicitly declared by the stream (by setting the **command-subscriber** field; see :ref:`example config below <Stream_config>`), or decided by the server (select the first outbound stream in the configuration file).
+
 - Streams can have any number of **handlers**. A stream passes each received *packet* through its handlers in order and publishes the result.
 - There are several stream classes that inherit from the base stream class. These child classes exist for handling the input and output of streams differently based on whether the inputs/output are ports or other streams and plugins. The appropriate stream type will be instantiated based on whether the stream is an inbound or outbound stream and based on the inputs/output specified in the stream's configs. If the input type of an inbound stream is an integer, it will be assumed to be a port. If it is a string, it will be assumed to be another stream name or plugin. Only outbound streams can have an output, and the output must be a port, not another stream or plugin.
 
 .. _Stream_config:
+
 Example configuration:
 
 .. code-block:: none
@@ -82,10 +85,12 @@ Example configuration:
             handlers:
                 - name: my_custom_handlers.TestbedCommandHandler
 
+
         - stream:
             name: command_flightlike_stream
             handlers:
                 - name: my_custom_handlers.FlightlikeCommandHandler
+            command-subscriber: True
 
         - stream:
             name: command_port_out_stream


### PR DESCRIPTION
- introduced concept of a command topic, which the server automatically create
- server will connect this topic to at most one outbound stream
- outbound stream config updated to include new field designating it
- if not outbound stream declares itself, then server will self-assign the first out stream
- updated server architecture docs to document the above
- CmdApi updated to send command+args to either ZMQ topic (default) or UDP.
- updated ait_cmd_send and ait_seq_send to include new options for specifying topic or udp.

Resolve #143 
