### PR TITLE
Issue #281 - Update CmdAPI with None udp_dest default

### DIFF
--- a/ait/core/api.py
+++ b/ait/core/api.py
@@ -101,7 +101,7 @@ class CmdAPI:
     Datagram Protocol (UDP) packets if udp_dest argument is set,
     else, command is sent via ZMQ topic.
     """
-    def __init__ (self, udp_dest, cmddict=None, verbose=False, cmdtopic=None):
+    def __init__ (self, udp_dest=None, cmddict=None, verbose=False, cmdtopic=None):
 
         if cmddict is None:
             cmddict = cmd.getDefaultCmdDict()
@@ -109,10 +109,9 @@ class CmdAPI:
         self._cmddict = cmddict
         self._verbose = verbose
 
-        ## Setup the destination of our commands and arguents based on destination
+        ## Setup the destination of our commands and arguments based on destination
         ## information.
         if udp_dest:
-
             ## Convert partial info to full tuple
             if type(udp_dest) is int:
                 udp_dest = (ait.DEFAULT_CMD_HOST, udp_dest)

--- a/ait/core/bin/ait_cmd_send.py
+++ b/ait/core/bin/ait_cmd_send.py
@@ -115,9 +115,6 @@ def main():
     udp      = args.udp
     topic    = args.topic
 
-    # dest will contain UDP info or None for 0MQ
-    dest     = None
-
     ## If UDP enabled, collect host/port info
     if udp:
         if host is not None:
@@ -125,7 +122,10 @@ def main():
         else:
             dest = port
 
-    cmdApi  = api.CmdAPI(dest, verbose=verbose, cmdtopic=topic)
+        cmdApi = api.CmdAPI(udp_dest=dest, verbose=verbose)
+    # Default CmdAPI connect hooks up to C&DH server 0MQ port
+    else:
+        cmdApi = api.CmdAPI(verbose=verbose, cmdtopic=topic)
 
     cmdArgs = cmdApi.parseArgs(args.command, *args.arguments)
 

--- a/ait/core/bin/ait_seq_send.py
+++ b/ait/core/bin/ait_seq_send.py
@@ -108,7 +108,6 @@ def main ():
     topic    = args.topic
     filename = args.filename
 
-    dest     = None
 
     ## If UDP enabled, collect host/port info
     if udp:
@@ -117,7 +116,10 @@ def main ():
         else:
             dest = port
 
-    cmdApi = api.CmdAPI(dest, verbose=verbose, cmdtopic=topic)
+        cmdApi = api.CmdAPI(udp_dest=dest, verbose=verbose)
+    # Default CmdAPI connect hooks up to C&DH server 0MQ port
+    else:
+        cmdApi = api.CmdAPI(verbose=verbose, cmdtopic=topic)
 
 
     try:


### PR DESCRIPTION
Update CmdAPI's upd_dest argument to default to None. Instantiation of
CmdAPI without additional arguments will result in a connection to the
C&DH global 0MQ command port.

Update CmdAPI instantiations in ait-[cmd|seq]-send scripts to take the
keyword argument into consideration.

Resolve #281 