### PR TITLE
Database API Result Handling and SQLite bug fixes and improvements

### DIFF
--- a/ait/core/db.py
+++ b/ait/core/db.py
@@ -21,10 +21,14 @@ commands and telemetry with several backends.
 from abc import ABCMeta, abstractmethod
 import datetime as dt
 import importlib
+import itertools
 import math
+import os.path
+
+import sqlite3
 
 import ait
-from ait.core import cfg, cmd, dmc, dtype, evr, tlm
+from ait.core import cfg, cmd, dmc, dtype, evr, log, tlm
 
 
 # Backend must implement DB-API 2.0 [PEP 249]
@@ -48,7 +52,7 @@ def create(database, tlmdict=None):
     """
     if tlmdict is None:
         tlmdict = tlm.getDefaultDict()
-    
+
     dbconn = connect(database)
 
     for name, defn in tlmdict.items():
@@ -114,6 +118,90 @@ if ait.config.get('database.backend'):
     use( ait.config.get('database.backend') )
 
 
+class AITDBResult():
+    '''AIT Database result wrapper.
+
+    :class:`AITDBResult` is a minimal wrapper around database query results /
+    errors. All AIT database APIs that execute a query will return their results
+    wrapped in an :class:`AITDBResult` object.
+
+    :class:`AITDbResult` tracks four main attributes. Generally, an unused attribute
+    will be None.
+
+    **query**
+        The query string(s) execute by the backend. This will be returned as a
+        String. Backends are free to format this as appropriate but, in general,
+        the contents of this will be a viable query that could be executed without
+        modification by the backend whenever possible.
+
+    **results**
+        The raw results from the backend library query. This field is populated by
+        an API query that doesn't further process results (e.g., into
+        :class:`ait.core.tlm.Packet`). Users will need to consult the appropriate
+        backend driver documentation for details on the format returned.
+
+    **packets**
+        A generator that returns :class:`ait.core.tlm.Packet` objects parsed from
+        the executed query. Interfacing with queried data as :class:`ait.core.tlm.Packet`
+        objects is the most use case for AIT's database APIs. All "high level" API
+        functions return their data as Packet objects. In general, a result
+        object will either have data accessible through **packets** or **results**,
+        but not both.
+
+    **errors**
+        An iterator of errors encountered during query execution. Depending on the
+        specific backend implementation, errors and query results (either in
+        **results** or **packets**) may or may not be mutually exclusive. Specific
+        API endpoints will document this.
+
+    **Example uses:**
+
+        # Query SQLite for all available packets and iterate over the results,
+        # printing them to stdout.
+        be = db.SQLiteBackend()
+        be.connect()
+        res = be.query_packets()
+        for packet in res.get_packets():
+            print(packet)
+    '''
+
+    def __init__(self, query=None, results=None, packets=None, errors=None):
+        self._query = query
+        self._results = results
+        self._packets = packets
+        self._errors = errors
+
+    @property
+    def query(self):
+        return self._query
+
+    @property
+    def errors(self):
+        return self._errors
+
+    @property
+    def results(self):
+        return self._results
+
+    @property
+    def has_packets(self):
+        return self._packets is not None
+
+    def get_packets(self):
+        if self._packets is not None:
+            yield from self._packets
+        else:
+            return []
+
+    def __repr__(self):
+        return (
+            f"AITDBResult("
+            f"has_results: {self._results is not None}, "
+            f"has_packets: {self._packets is not None}, "
+            f"has_errors: {self._errors is not None})"
+        )
+
+
 class GenericBackend(object):
     ''' Generic database backend abstraction
 
@@ -156,6 +244,9 @@ class GenericBackend(object):
             Take a string defining a database query and return the results. The
             format of the results is backend specific.
 
+        query_packets
+            Query for packet types with optional filters.
+
         close
             Close the connection to the database instance and handle any cleanup
     '''
@@ -175,27 +266,50 @@ class GenericBackend(object):
 
     @abstractmethod
     def connect(self, **kwargs):
-        ''' Connect to a backend's database instance. '''
+        '''Connect to a backend's database instance.'''
         pass
 
     @abstractmethod
     def create(self, **kwargs):
-        ''' Create a database in the instance. '''
+        '''Create a database in the instance.'''
         pass
 
     @abstractmethod
     def insert(self, packet, **kwargs):
-        ''' Insert a record into the database. '''
+        '''Insert a record into the database.'''
         pass
 
     @abstractmethod
     def query(self, query, **kwargs):
-        ''' Query the database instance and return results. '''
+        '''Query the database instance and return results.'''
+        pass
+
+    @abstractmethod
+    def query_packets(self, packets=None, start_time=None, end_time=None, **kwargs):
+        '''Query the database instance for packet objects
+
+        Return all packets of the defined type from the data store, filtering
+        over an optional time range. If no parameters are specified, this will
+        return all data for all packet types as Packet objects.
+        '''
+        pass
+
+    @classmethod
+    @abstractmethod
+    def create_packet_from_result(self, packet_name, result):
+        '''Return an AIT Packet from a given database query result item
+
+        Creates and returns an AIT Packet denoted by `packet_name` with
+        field values set given the contents of `result`. Values that are
+        missing in the result will be defaulted in the returned Packet.
+        Specific implementations will have caveats related to their backend
+        and the limitations of the API.
+        '''
         pass
 
     @abstractmethod
     def close(self, **kwargs):
-        ''' Close connection to the database instance. '''
+        '''Close connection to the database instance.'''
         pass
 
 
@@ -251,11 +365,11 @@ class InfluxDBBackend(GenericBackend):
           the config key **database.dbname** or the kwargs argument
           **database**. Defaults to **ait**.
         '''
-        host = ait.config.get('database.host', kwargs.get('host', 'localhost'))
-        port = ait.config.get('database.port', kwargs.get('port', 8086))
-        un = ait.config.get('database.un', kwargs.get('un', 'root'))
-        pw = ait.config.get('database.pw', kwargs.get('pw', 'root'))
-        dbname = ait.config.get('database.dbname', kwargs.get('database', 'ait'))
+        host = kwargs.get('host', ait.config.get('database.host', 'localhost'))
+        port = kwargs.get('port', ait.config.get('database.port', 8086))
+        un = kwargs.get('un', ait.config.get('database.un', 'root'))
+        pw = kwargs.get('pw', ait.config.get('database.pw', 'root'))
+        dbname = kwargs.get('database', ait.config.get('database.dbname', 'ait'))
 
         self._conn = self._backend.InfluxDBClient(host, port, un, pw)
 
@@ -273,7 +387,7 @@ class InfluxDBBackend(GenericBackend):
           The database name to create. Passed as either the config
           key **database.dbname** or the kwargs argument
           **database**. Defaults to **ait**.
-        
+
         Raises:
             AttributeError:
                 If a connection to the database doesn't exist
@@ -303,7 +417,7 @@ class InfluxDBBackend(GenericBackend):
             tags
                 Optional kwargs argument for specifying a dictionary of tags to
                 include when adding the values. Defaults to nothing.
-        
+
         '''
         fields = {}
         pd = packet._defn
@@ -313,7 +427,7 @@ class InfluxDBBackend(GenericBackend):
 
             if pd.history and defn.name in pd.history:
                 val = getattr(packet.history, defn.name)
-            
+
             if val is not None and not (isinstance(val, float) and math.isnan(val)):
                 fields[defn.name] = val
 
@@ -324,7 +438,8 @@ class InfluxDBBackend(GenericBackend):
         tags = kwargs.get('tags', {})
 
         if isinstance(time, dt.datetime):
-            time = time.strftime("%Y-%m-%dT%H:%M:%S")
+            # time = time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            time = time.strftime(dmc.RFC3339_Format)
 
         data = {
             'measurement': pd.name,
@@ -337,8 +452,8 @@ class InfluxDBBackend(GenericBackend):
 
         self._conn.write_points([data])
 
-    def query(self, query, **kwargs):
-        ''' Query the database and return results
+    def _query(self, query, **kwargs):
+        '''Query the database and return results
 
         Queries the Influx instance and returns a ResultSet of values. For
         API documentation for InfluxDB-Python check out the project
@@ -348,13 +463,140 @@ class InfluxDBBackend(GenericBackend):
             query
                 The query string to send to the database
         '''
-        return self._conn.query(query)
+        return self._conn.query(query, **kwargs)
+
+    def query(self, query, **kwargs):
+        '''Query the database and return results
+
+        Queries the Influx instance and returns a ResultSet of values. For
+        API documentation for InfluxDB-Python check out the project
+        documentation. https://github.com/influxdata/influxdb-python
+
+        Arguments:
+            query:
+                The query string to send to the database
+
+        Returns:
+            An :class:`AITDBResult` with the database query results set in
+            **results** or errors recorded in **errors**.
+        '''
+        try:
+            db_res = self._query(query)
+            return AITDBResult(query=query, results=db_res)
+        except self._backend.exceptions.InfluxDBClientError as e:
+            log.error(f'query_time_range failed with exception: {e}')
+            return AITDBResult(query=query, errors=[str(e)])
+
+    def query_packets(self, packets=None, start_time=None, end_time=None, **kwargs):
+        '''Query the database for packet types over a time range.
+
+        Query the database for packet types over a time range. By default, all packet
+        types will be queried from the start of the GPS time epoch to current time.
+        In other words, you will (probably) receive everything in the database.
+        Be careful!
+
+        .. note:
+            In general, this function assumes you're automatically inserting packet data
+            via AIT's database APIs. If you're handling your data with a custom
+            implementation it may or may not work.
+
+        Arguments:
+            packets: An iterator containing the packet names over which to query. (
+                default: All packet types defined in the telemetry dictionary)
+
+            start_time: A :class:`datetime.datetime` object defining the query time
+                range start inclusively. (default: The start of the GPS time Epoch)
+
+            end_time: A :class:`datetime.datetime` object defining the query time
+                range end inclusively. (default: The current UTC Zulu time).
+
+        Additional Keyword Arguments:
+            yield_packet_time: If True, the packet generator will yield results
+                in the form (packet time as datetime object, Packet object). This
+                provides access to the time field associated with the packet in
+                the database.
+
+            **kwargs**: Additional kwargs are passed to the backend query without
+                modification.
+
+        Returns:
+            An :class:`AITDBResult` with **packets** set to a generator of all
+                packet objects returned by the query in time-sorted order. Otherwise,
+                **errors** will contain any encountered errors.
+
+        Raises:
+            ValueError: If a provided packet type name cannot be located in the
+                telemetry dictionary.
+        '''
+        if packets is not None:
+            tlm_dict = tlm.getDefaultDict()
+            for name in packets:
+                if name not in tlm_dict:
+                    msg = f'Invalid packet name "{name}" provided'
+                    log.error(msg)
+                    raise ValueError(msg)
+            pkt_names = ', '.join(packets)
+        else:
+            pkt_names = ', '.join([f'"{i}"' for i in tlm.getDefaultDict().keys()])
+
+        if start_time is not None:
+            stime = start_time.strftime(dmc.RFC3339_Format)
+        else:
+            stime = dmc.GPS_Epoch.strftime(dmc.RFC3339_Format)
+
+        if end_time is not None:
+            etime = end_time.strftime(dmc.RFC3339_Format)
+        else:
+            etime = dt.datetime.utcnow().strftime(dmc.RFC3339_Format)
+
+        query_string = f"SELECT * FROM {pkt_names} WHERE time >= '{stime}' AND time <= '{etime}'"
+
+        try:
+            db_res = self._query(query_string, **kwargs)
+        except self._backend.exceptions.InfluxDBClientError as e:
+            log.error(f'query_time_range failed with exception: {e}')
+            return AITDBResult(query=query_string, errors=[str(e)])
+
+        def influx_results_gen(db_res, **kwargs):
+            from ait.core import dmc
+
+            res_items = db_res.items()
+            pkt_names = [i[0][0] for i in res_items]
+            pkt_gens = [i[1] for i in res_items]
+
+            for packets in itertools.zip_longest(*pkt_gens, fillvalue=None):
+                pkt_conv = [
+                    (
+                        dt.datetime.strptime(d['time'], dmc.RFC3339_Format),
+                        InfluxDBBackend.create_packet_from_result(pkt_names[i], d)
+                    )
+                    for i, d in enumerate(packets)
+                    if d is not None
+                ]
+
+                pkt_conv.sort(key=lambda x: x[0])
+
+                for t, pkt in pkt_conv:
+                    if kwargs.get('yield_packet_time', False):
+                        yield (t, pkt)
+                    else:
+                        yield pkt
+
+        return AITDBResult(
+            query=query_string,
+            packets=influx_results_gen(db_res, **kwargs)
+        )
+
 
     def close(self, **kwargs):
         ''' Close the database connection '''
         if self._conn:
             self._conn.close()
 
+    @ait.deprecated(
+        'create_packets_from_results has been deprecated. Near equivalent functionality '
+        'is available in create_packet_from_result.'
+    )
     @classmethod
     def create_packets_from_results(self, packet_name, result_set):
         ''' Generate AIT Packets from a InfluxDB query ResultSet
@@ -376,7 +618,7 @@ class InfluxDBBackend(GenericBackend):
         Returns
             A list of packets extracted from the ResultSet object or None if
             an invalid packet name is supplied.
-                
+
         '''
         try:
             pkt_defn = tlm.getDefaultDict()[packet_name]
@@ -384,43 +626,87 @@ class InfluxDBBackend(GenericBackend):
             log.error('Unknown packet name {} Unable to unpack ResultSet'.format(packet_name))
             return None
 
-        pkt = tlm.Packet(pkt_defn)
+        return [
+            InfluxDBBackend.create_packet_from_result(packet_name, r)
+            for r in result_set.get_points()
+        ]
 
-        pkts = []
-        for r in result_set.get_points():
-            new_pkt = tlm.Packet(pkt_defn)
+    @classmethod
+    def create_packet_from_result(self, packet_id, result):
+        '''Create an AIT Packet from an InfluxDB query ResultSet item
 
-            for f, f_defn in pkt_defn.fieldmap.items():
-                field_type_name = f_defn.type.name
-                if field_type_name == 'CMD16':
-                    if cmd.getDefaultDict().opcodes.get(r[f], None):
-                        setattr(new_pkt, f, cmd_def.name)
-                elif field_type_name == 'EVR16':
-                    if evr.getDefaultDict().codes.get(r[f], None):
-                        setattr(new_pkt, f, r[f])
-                elif field_type_name == 'TIME8':
-                    setattr(new_pkt, f, r[f] / 256.0)
-                elif field_type_name == 'TIME32':
-                    new_val = dmc.GPS_Epoch + dt.timedelta(seconds=r[f])
-                    setattr(new_pkt, f, new_val)
-                elif field_type_name == 'TIME40':
-                    sec = int(r[f])
-                    microsec = r[f] * 1e6
-                    new_val = dmc.GPS_Epoch + dt.timedelta(seconds=sec, microseconds=microsec)
-                    setattr(new_pkt, f, new_val)
-                elif field_type_name == 'TIME64':
-                    sec = int(r[f])
-                    microsec = r[f] % 1 * 1e6
-                    new_val = dmc.GPS_Epoch + dt.timedelta(seconds=sec, microseconds=microsec)
-                    setattr(new_pkt, f, new_val)
-                else:
-                    try:
-                        setattr(new_pkt, f, r[f])
-                    except KeyError:
-                        log.info('Field not found in query results {} Skipping ...'.format(f))
+        Extract Influx DB query results entry into an AIT packet. This
+        assumes that telemetry data was inserted in the format generated by
+        :func:`InfluxDBBackend.insert`. Complex types such as CMD16 and EVR16 are
+        evaluated if they can be properly encoded from the raw value in the
+        query result. If there is no opcode / EVR-code for a particular raw
+        value the value is skipped (and thus defaulted to 0).
 
-            pkts.append(new_pkt)
-        return pkts
+        Arguments
+            packet_id (string or PacketDefinition)
+                The "id" for the packet to create. If packet_id is a string it must
+                name a valid PacketDefintion in the telemetry dictionary. Otherwise,
+                it must be a PacketDefinition.
+
+            result (dict)
+                The :class:`influxdb.resultset.ResultSet` entry from which values
+                should be extracted to form the AIT packet
+
+
+        Returns
+            A :class:`ait.core.tlm.Packet` with values initialized from the values in the
+            ResultSet entry. If a field cannot be located in the result entry it will left
+            as the default value in the Packet or set to None if it's a CMD / EVR type.
+        '''
+        if isinstance(packet_id, str):
+            try:
+                pkt_defn = tlm.getDefaultDict()[packet_id]
+            except KeyError:
+                log.error(f'Unknown packet name {packet_id} Unable to unpack ResultSet')
+                return None
+        elif isinstance(packet_id, tlm.PacketDefinition):
+            pkt_defn = packet_id
+        else:
+            log.error(f'Unknown packet id type {packet_id}. Unable to unpack ResultSet')
+            return None
+
+        new_pkt = tlm.Packet(pkt_defn)
+        cmd_dict = cmd.getDefaultDict()
+        evr_dict = evr.getDefaultDict()
+
+        for f, f_defn in pkt_defn.fieldmap.items():
+            field_type_name = f_defn.type.name
+            if field_type_name == 'CMD16':
+                if cmd_dict.opcodes.get(result[f], None):
+                    cmd_def = cmd_dict.opcodes.get(result[f])
+                    setattr(new_pkt, f, cmd_def.name)
+            elif field_type_name == 'EVR16':
+                if evr_dict.codes.get(result[f], None):
+                    evr_def = evr_dict.codes.get(result[f])
+                    setattr(new_pkt, f, evr_def.name)
+            elif field_type_name == 'TIME8':
+                setattr(new_pkt, f, result[f] / 256.0)
+            elif field_type_name == 'TIME32':
+                new_val = dmc.GPS_Epoch + dt.timedelta(seconds=result[f])
+                setattr(new_pkt, f, new_val)
+            elif field_type_name == 'TIME40':
+                sec = int(result[f])
+                microsec = result[f] % 1 * 1e6
+                new_val = dmc.GPS_Epoch + dt.timedelta(seconds=sec, microseconds=microsec)
+                setattr(new_pkt, f, new_val)
+            elif field_type_name == 'TIME64':
+                sec = int(result[f])
+                microsec = result[f] % 1 * 1e6
+                new_val = dmc.GPS_Epoch + dt.timedelta(seconds=sec, microseconds=microsec)
+                setattr(new_pkt, f, new_val)
+            else:
+                try:
+                    setattr(new_pkt, f, result[f])
+                except KeyError:
+                    log.info('Field not found in query results {} Skipping ...'.format(f))
+
+
+        return new_pkt
 
 
 class SQLiteBackend(GenericBackend):
@@ -434,7 +720,7 @@ class SQLiteBackend(GenericBackend):
     def connect(self, **kwargs):
         ''' Connect to a SQLite instance
         If the database doesn't exist it is created first via :func:`create`.
-        
+
         **Configuration Parameters**
 
         database name
@@ -443,39 +729,23 @@ class SQLiteBackend(GenericBackend):
           **database**. Defaults to **ait.db**.
         '''
 
-        dbname = ait.config.get('database.dbname', kwargs.get('database', None))
-        if dbname:
-            self._conn = self._backend.connect(dbname)
-        else:
+        dbname = kwargs.get('database', ait.config.get('database.dbname', 'ait.db'))
+        db_exists = os.path.isfile(dbname)
+
+        self._conn = self._backend.connect(dbname)
+        if not db_exists:
             self.create()
 
     def create(self, **kwargs):
-        ''' Create and connect to a SQLite instance
-        Since creation and connection are intertwined in SQLite,
-        a pre-existing connection is not required unlike InfluxDB.
-        A skeleton database is built with the telemetry dictionary
-        since tables must be pre-created in SQLite.
+        ''' Create packet tables in the connected database
 
         **Configuration Parameters**
-
-        database name
-          The database name to create. Passed as either the config
-          key **database.dbname** or the kwargs argument
-          **database**. Defaults to **ait.db**.
 
         tlmdict
             The :class:`ait.core.tlm.TlmDict` instance to use. Defaults to
             the currently configured telemetry dictionary.
         '''
-
         tlmdict = kwargs.get('tlmdict', tlm.getDefaultDict())
-
-        dbname = ait.config.get('database.dbname', kwargs.get('database', None))
-        if dbname:
-            self._conn = self._backend.connect(dbname)
-        else:
-            self._conn = self._backend.connect('ait.db')
-
         for name, defn in tlmdict.items():
             self._create_table(defn)
 
@@ -489,8 +759,7 @@ class SQLiteBackend(GenericBackend):
                 should be made.
         '''
         time_def = 'time DATETIME DEFAULT(STRFTIME(\'%Y-%m-%dT%H:%M:%fZ\', \'NOW\')), '
-        cols = ('%s %s' % (defn.name, self._getTypename(defn)) for defn in packet_defn.fields)
-        sql  = 'CREATE TABLE IF NOT EXISTS "%s" (%s)' % (packet_defn.name, time_def + ', '.join(cols))
+        sql  = 'CREATE TABLE IF NOT EXISTS "%s" (%s)' % (packet_defn.name, time_def + 'PKTDATA BLOB NOT NULL')
 
         self._conn.execute(sql)
         self._conn.commit()
@@ -504,41 +773,169 @@ class SQLiteBackend(GenericBackend):
                 the database
 
         '''
-        names = []
-        values = [ ]
-        pd     = packet._defn
-
-        for defn in pd.fields:
-            val = getattr(packet.raw, defn.name)
-
-            if val is None and defn.name in pd.history:
-                val = getattr(packet.history, defn.name)
-
-            names.append(defn.name)
-            values.append(val)
-
-        qmark = ['?'] * len(values)
-        sql   = 'INSERT INTO "%s" (%s) VALUES (%s)' % (pd.name, ', '.join(names), ', '.join(qmark))
-
-        self._conn.execute(sql, values)
+        sql = f'INSERT INTO "{packet._defn.name}" (PKTDATA) VALUES (?)'
+        self._conn.execute(sql, (sqlite3.Binary(packet._data),))
         self._conn.commit()
 
-    def query(self, query, **kwargs):
+    def _query(self, query, **kwargs):
         ''' Query the database and return results
 
-        Queries the SQLite instance and returns a list of tuples of values.
+        Queries the SQLite instance and returns raw results.
 
-        Arguments
-            query
+        Arguments:
+            query:
                 The query string to send to the database
+
+        Returns:
+            The raw results of the database query.
+
+        Raises:
+            Any sqlite3.OperationalError or other sqlite-specific exceptions
+            raised from the driver during execution of the query.
         '''
         return self._conn.execute(query)
-    
+
+    def query(self, query, **kwargs):
+        '''Query the database and return results
+
+        Queries the SQLite instance and returns the raw results object.
+        API documentation for Python's SQLite3 interface provides format
+        details. https://docs.python.org/3.7/library/sqlite3.html
+
+        Arguments:
+            query:
+                The query string to send to the database
+
+        Returns:
+            An :class:`AITDBResult` with the database query results set in
+            **results** or errors recorded in **errors**.
+        '''
+        try:
+            results = self._query(query, **kwargs)
+            return AITDBResult(query=query, results=results)
+        except self._backend.OperationalError as e:
+            log.error(f'query_time_range failed with exception: {e}')
+            return AITDBResult(query=query, errors=[str(e)])
+
+    def query_packets(self, packets=None, start_time=None, end_time=None, **kwargs):
+        '''Query the database for packet types over a time range.
+
+        Query the database for packet types over a time range. By default, all packet
+        types will be queried from the start of the GPS time epoch to current time.
+        In other words, you will (probably) receive everything in the database.
+        Be careful!
+
+        .. note:
+            In general, this function assumes you're automatically inserting packet data
+            via AIT's database APIs. If you're handling your data with a custom
+            implementation it may or may not work.
+
+        Arguments:
+            packets: An iterator containing the packet names over which to query. (
+                default: All packet types defined in the telemetry dictionary)
+
+            start_time: A :class:`datetime.datetime` object defining the query time
+                range start inclusively. (default: The start of the GPS time Epoch)
+
+            end_time: A :class:`datetime.datetime` object defining the query time
+                range end inclusively. (default: The current UTC Zulu time).
+
+        Additional Keyword Arguments:
+            yield_packet_time: If True, the packet generator will yield results
+                in the form (packet time as datetime object, Packet object). This
+                provides access to the time field associated with the packet in
+                the database.
+
+            **kwargs**: Additional kwargs are passed to the backend query without
+                modification.
+
+        Returns:
+            An :class:`AITDBResult` with **packets** set to a generator of all
+                packet objects returned by the query in time-sorted order. The
+                **errors** attribute will include any errors encountered.
+
+                Note, because queries are broken up by packet type, this could contain
+                both results and errors.
+
+        Raises:
+            ValueError: If a provided packet type name cannot be located in the
+                telemetry dictionary.
+        '''
+        if packets is not None:
+            tlm_dict = tlm.getDefaultDict()
+            for name in packets:
+                try:
+                    tlm_dict[name]
+                except KeyError:
+                    msg = 'Invalid packet name "{name}" provided'
+                    log.error(msg)
+                    raise ValueError(msg)
+        else:
+            packets = list(tlm.getDefaultDict().keys())
+
+        if start_time is not None:
+            stime = start_time.strftime(dmc.RFC3339_Format)
+        else:
+            stime = dmc.GPS_Epoch.strftime(dmc.RFC3339_Format)
+
+        if end_time is not None:
+            etime = end_time.strftime(dmc.RFC3339_Format)
+        else:
+            etime = dt.datetime.utcnow().strftime(dmc.RFC3339_Format)
+
+        results = []
+        errs = []
+        query = []
+        for pkt in packets:
+            query_string = f'SELECT * FROM "{pkt}" WHERE time >= "{stime}" AND time <= "{etime}" ORDER BY time ASC'
+            query.append(query_string)
+
+            try:
+                results.append((pkt, self._query(query_string)))
+            except self._backend.OperationalError as e:
+                log.error(f'query_time_range failed with exception: {e}')
+                errs.append(str(e))
+
+
+        def sqlite_results_gen(results, **kwargs):
+            from ait.core import dmc
+
+            for packets in itertools.zip_longest(*[r[1] for r in results], fillvalue=None):
+                pkt_conv = [
+                    (
+                        dt.datetime.strptime(d[0], dmc.RFC3339_Format),
+                        SQLiteBackend.create_packet_from_result(results[i][0], d[1])
+                    )
+                    for i, d in enumerate(packets)
+                    if d is not None
+                ]
+
+                pkt_conv.sort(key=lambda x: x[0])
+
+                for t, pkt in pkt_conv:
+                    if kwargs.get('yield_packet_time', False):
+                        yield (t, pkt)
+                    else:
+                        yield pkt
+
+        return AITDBResult(
+            query='; '.join(query),
+            packets=sqlite_results_gen(results, **kwargs),
+            errors=errs if len(errs) > 0 else None
+        )
+
     def close(self, **kwargs):
         ''' Close the database connection. '''
         if self._conn:
             self._conn.close()
 
-    def _getTypename(self, defn):
-        """ Returns the SQL typename required to store the given FieldDefinition """
-        return 'REAL' if defn.type.float or 'TIME' in defn.type.name or defn.dntoeu else 'INTEGER'
+    @classmethod
+    def create_packet_from_result(self, packet_name, data):
+        try:
+            pkt_defn = tlm.getDefaultDict()[packet_name]
+        except KeyError:
+            log.error('Unknown packet name {}. Unable to unpack SQLite result'.format(packet_name))
+            return None
+
+        pkt = tlm.Packet(pkt_defn)
+        return tlm.Packet(pkt_defn, data=data)

--- a/ait/core/dmc.py
+++ b/ait/core/dmc.py
@@ -40,6 +40,7 @@ TwoPi     = 2 * math.pi
 
 DOY_Format = '%Y-%jT%H:%M:%SZ'
 ISO_8601_Format = '%Y-%m-%dT%H:%M:%SZ'
+RFC3339_Format = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 _DEFAULT_FILE_NAME = 'leapseconds.dat'
 LeapSeconds = None

--- a/ait/core/test/test_db.py
+++ b/ait/core/test/test_db.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2.7
-
 # Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
 # Bespoke Link to Instruments and Small Satellites (BLISS)
 #
@@ -15,13 +13,48 @@
 # information to foreign countries or providing access to foreign persons.
 
 import datetime as dt
+import inspect
 import os
+import sqlite3
 import unittest
 
+import nose.tools
 from unittest import mock
 
+import ait.core.cfg as cfg
 import ait.core.db as db
+import ait.core.dmc as dmc
 import ait.core.tlm as tlm
+
+
+class TestDBResultObject(unittest.TestCase):
+    def test_default_init(self):
+        res = db.AITDBResult()
+        assert res.query is None
+        assert res.results is None
+        assert res._packets is None
+        assert list(res.get_packets()) == []
+        assert res.errors is None
+
+        query = 'foobar'
+        results = [1, 2, 3]
+        errors = ['error1', 'error2']
+        res = db.AITDBResult(query=query, results=results, errors=errors)
+        assert res.query == query
+        assert res.results == results
+        assert res.errors == errors
+
+    def test_get_packets(self):
+        # AITDBResult expects to receive packet results to be provided
+        # in a form from which it can `yield from`. If it doesn't get
+        # an object it returns an empty list.
+
+        res = db.AITDBResult()
+        assert list(res.get_packets()) == []
+
+        res = db.AITDBResult(packets=range(5))
+        assert list(res.get_packets()) == [0, 1, 2, 3, 4]
+        assert inspect.isgenerator(res.get_packets())
 
 
 class TestInfluxDBBackend(unittest.TestCase):
@@ -117,7 +150,7 @@ class TestInfluxDBBackend(unittest.TestCase):
         sqlbackend.insert(pkt, time=now)
         sqlbackend._conn.write_points.assert_called_with([{
             'measurement': 'Packet1',
-            'time': now.strftime('%Y-%m-%dT%H:%M:%S'),
+            'time': now.strftime(dmc.RFC3339_Format),
             'tags': {},
             'fields': {
                 'col1': 1,
@@ -165,12 +198,280 @@ class TestInfluxDBBackend(unittest.TestCase):
         os.remove(self.test_yaml_file)
 
     @mock.patch('importlib.import_module')
-    def test_influx_query(self, importlib_mock):
+    def test_influx_query_calldown(self, importlib_mock):
         sqlbackend = db.InfluxDBBackend()
         sqlbackend._conn = mock.MagicMock()
 
         sqlbackend.query('SELECT * FROM table')
         sqlbackend._conn.query.assert_called_with('SELECT * FROM table')
+
+    def test_query_return_types(self):
+        # This test is only relevant if we can raise a specific exception. Skip otherwise
+        # Tested and running with python-influxdb=5.3.0
+        try:
+            sqlbackend = db.InfluxDBBackend()
+        except cfg.AitConfigError:
+            self.skipTest('Test requires database library to be installed')
+        sqlbackend._conn = mock.MagicMock()
+        sqlbackend._query = mock.MagicMock()
+
+        # Check that a successful query returns a properly formatted AITDBResult
+        ret_val = [1, 2, 3]
+        query_string = 'select * from table'
+        sqlbackend._query.return_value = ret_val
+        results = sqlbackend.query(query_string)
+        assert isinstance(results, db.AITDBResult)
+        assert results.query == query_string
+        assert results.results == ret_val
+
+        # Check that a failed query returns a properly formatted AITDBResult
+        sqlbackend._query.side_effect = sqlbackend._backend.exceptions.InfluxDBClientError('foo')
+        results = sqlbackend.query(query_string)
+        assert results.query == query_string
+        assert results.errors == ['foo']
+
+    @mock.patch('importlib.import_module')
+    def test_query_packets_calldown(self, importlib_mock):
+        sqlbackend = db.InfluxDBBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        start = dmc.GPS_Epoch
+        end = dt.datetime.utcnow()
+        packets = [list(tlm.getDefaultDict().keys())[0]]
+
+        sqlbackend.query_packets(packets=packets, start_time=start, end_time=end)
+
+        packets = ', '.join(packets)
+        start = start.strftime(dmc.RFC3339_Format)
+        end = end.strftime(dmc.RFC3339_Format)
+        query = f"SELECT * FROM {packets} WHERE time >= '{start}' AND time <= '{end}'"
+
+        assert sqlbackend._conn.query.call_args[0][0] == query
+
+    @mock.patch('importlib.import_module')
+    def test_query_packets_arg_handling(self, importlib_mock):
+        sqlbackend = db.InfluxDBBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        # Test no packet provided handling
+        #######################################
+        start = dmc.GPS_Epoch
+        end = dt.datetime.utcnow()
+
+        sqlbackend.query_packets(start_time=start, end_time=end)
+
+        packets = ', '.join([f'"{i}"' for i in tlm.getDefaultDict().keys()])
+        start = start.strftime(dmc.RFC3339_Format)
+        end = end.strftime(dmc.RFC3339_Format)
+        query = f"SELECT * FROM {packets} WHERE time >= '{start}' AND time <= '{end}'"
+
+        assert sqlbackend._conn.query.call_args[0][0] == query
+        sqlbackend._conn.reset_mock()
+
+        # Test no start time handling
+        #######################################
+        end = dt.datetime.utcnow()
+
+        sqlbackend.query_packets(end_time=end)
+
+        packets = ', '.join([f'"{i}"' for i in tlm.getDefaultDict().keys()])
+        start = dmc.GPS_Epoch.strftime(dmc.RFC3339_Format)
+        end = end.strftime(dmc.RFC3339_Format)
+        query = f"SELECT * FROM {packets} WHERE time >= '{start}' AND time <= '{end}'"
+
+        assert sqlbackend._conn.query.call_args[0][0] == query
+        sqlbackend._conn.reset_mock()
+
+        # Test no end time handling
+        #######################################
+        sqlbackend.query_packets()
+
+        packets = ', '.join([f'"{i}"' for i in tlm.getDefaultDict().keys()])
+        start = dmc.GPS_Epoch.strftime(dmc.RFC3339_Format)
+        end = dt.datetime.utcnow()
+        query = f"SELECT * FROM {packets} WHERE time >= '{start}' AND time <= '{end}'"
+
+        exec_end_time = dt.datetime.strptime(
+            sqlbackend._conn.query.call_args[0][0].split("'")[-2],
+            dmc.RFC3339_Format
+        )
+
+        assert (end - exec_end_time).seconds < 1
+        sqlbackend.query_packets()
+
+        # Test bad packet name exception
+        #######################################
+        nose.tools.assert_raises(
+            ValueError,
+            sqlbackend.query_packets,
+            packets=['not_a_valid_packet']
+        )
+
+    def test_query_fail_handling(self):
+        # This test is only relevant if we can raise a specific exception. Skip otherwise
+        # Tested and running with python-influxdb=5.3.0
+        try:
+            sqlbackend = db.InfluxDBBackend()
+        except cfg.AitConfigError:
+            self.skipTest('Test requires database library to be installed')
+
+        sqlbackend._conn = mock.MagicMock()
+        sqlbackend._query = mock.MagicMock()
+        sqlbackend._query.side_effect = sqlbackend._backend.exceptions.InfluxDBClientError('foo')
+
+        res = sqlbackend.query_packets()
+        assert res.errors == ['foo']
+
+    @mock.patch('importlib.import_module')
+    def test_query_success_handling(self, importlib_mock):
+        sqlbackend = db.InfluxDBBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        res_mock = mock.MagicMock()
+        res_mock.items = mock.MagicMock(return_value=[
+            (
+                ('1553_HS_Packet', None), [
+                    {
+                        'time': '2020-11-17T21:12:17.677316Z',
+                        'Current_A': 0,
+                        'Voltage_A': 0,
+                        'Voltage_B': 0,
+                        'Voltage_C': 0,
+                        'Voltage_D': 0
+                    }, {
+                        'time': '2020-11-17T21:12:18.675379Z',
+                        'Current_A': 1,
+                        'Voltage_A': 1,
+                        'Voltage_B': 1,
+                        'Voltage_C': 1,
+                        'Voltage_D': 1
+                    }, {
+                        'time': '2020-11-17T21:12:19.682312Z',
+                        'Current_A': 2,
+                        'Voltage_A': 2,
+                        'Voltage_B': 2,
+                        'Voltage_C': 2,
+                        'Voltage_D': 2
+                    }
+                ]
+            )]
+        )
+
+        sqlbackend._query = mock.MagicMock(return_value=res_mock)
+
+        res = sqlbackend.query_packets()
+
+        assert isinstance(res, db.AITDBResult)
+        assert res._packets is not None
+
+        res_pkts = list(res.get_packets())
+        assert len(res_pkts) == 3
+        assert isinstance(res_pkts[0], tlm.Packet)
+
+        assert res_pkts[0].Voltage_A == 0
+        assert res_pkts[1].Voltage_A == 1
+        assert res_pkts[2].Voltage_A == 2
+
+    @mock.patch('importlib.import_module')
+    def test_query_packet_time_inclusion(self, importlib_mock):
+        sqlbackend = db.InfluxDBBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        ret_data = [
+            (
+                ('1553_HS_Packet', None), [
+                    {
+                        'time': '2020-11-17T21:12:17.677316Z',
+                        'Current_A': 0,
+                        'Voltage_A': 0,
+                        'Voltage_B': 0,
+                        'Voltage_C': 0,
+                        'Voltage_D': 0
+                    }, {
+                        'time': '2020-11-17T21:12:18.675379Z',
+                        'Current_A': 1,
+                        'Voltage_A': 1,
+                        'Voltage_B': 1,
+                        'Voltage_C': 1,
+                        'Voltage_D': 1
+                    }, {
+                        'time': '2020-11-17T21:12:19.682312Z',
+                        'Current_A': 2,
+                        'Voltage_A': 2,
+                        'Voltage_B': 2,
+                        'Voltage_C': 2,
+                        'Voltage_D': 2
+                    }
+                ]
+            )]
+        res_mock = mock.MagicMock()
+        res_mock.items = mock.MagicMock(return_value=ret_data)
+
+        sqlbackend._query = mock.MagicMock(return_value=res_mock)
+
+        res = sqlbackend.query_packets(yield_packet_time=True)
+
+        assert isinstance(res, db.AITDBResult)
+        assert res._packets is not None
+
+        res_pkts = list(res.get_packets())
+        assert len(res_pkts) == 3
+        assert isinstance(res_pkts[0], tuple)
+
+        for i, test_data in enumerate(ret_data[0][1]):
+            assert dt.datetime.strptime(test_data['time'], dmc.RFC3339_Format) == res_pkts[i][0]
+            assert res_pkts[i][1].Voltage_A == i
+
+    @mock.patch('importlib.import_module')
+    def test_packet_creation_from_result(self, importlib_mock):
+        yaml_doc = """
+        - !Packet
+          name: TestPacket
+          fields:
+            - !Field
+              name: SampleField
+              type: MSB_U16
+            - !Field
+              name: SampleTime
+              type: TIME64
+            - !Field
+              name: SampleTime8
+              type: TIME8
+            - !Field
+              name: SampleTime32
+              type: TIME32
+            - !Field
+              name: SampleTime40
+              type: TIME40
+            - !Field
+              name: SampleEvr16
+              type: EVR16
+            - !Field
+              name: SampleCmd16
+              type: CMD16
+        """
+        with open(self.test_yaml_file, 'wt') as out:
+            out.write(yaml_doc)
+
+        tlmdict = tlm.TlmDict(self.test_yaml_file)
+
+        res = {
+            'time': '2020-11-17T21:12:17.677316Z',
+            'SampleField': 1,
+            'SampleTime': 33752069.101124,
+            'SampleTime8': 100,
+            'SampleTime32': 168496141,
+            'SampleTime40': 1113733097.03125,
+            'SampleCmd16': 1,
+            'SampleEvr16': 1
+        }
+
+        pkt = db.InfluxDBBackend.create_packet_from_result(tlmdict['TestPacket'], res)
+
+        for f in pkt._defn.fields:
+            assert getattr(pkt.raw, f.name) == res[f.name]
+
+        os.remove(self.test_yaml_file)
 
 
 class TestSQLiteBackend(unittest.TestCase):
@@ -187,14 +488,40 @@ class TestSQLiteBackend(unittest.TestCase):
         sqlbackend = db.SQLiteBackend()
         sqlbackend._backend = mock.MagicMock()
 
+        # Check default database naming
         sqlbackend.connect()
         assert sqlbackend._backend.connect.called
         sqlbackend._backend.connect.assert_called_with('ait.db')
         sqlbackend._backend.reset_mock()
 
+        # Check custom database naming
         sqlbackend.connect(database='foo.db')
         assert sqlbackend._backend.connect.called
         sqlbackend._backend.connect.assert_called_with('foo.db')
+
+        # Backend should only call self.create if a database doesn't exist
+        #
+        # Mock return_value handling wasn't cooperating with decorators
+        # so we'll handle it manually instead ...
+        import os.path
+        isfile_mock = mock.MagicMock(return_value=True)
+        isfile_orig = os.path.isfile
+        os.path.isfile = isfile_mock
+
+        sqlbackend.create = mock.MagicMock()
+
+        assert isfile_mock is os.path.isfile
+        isfile_mock.return_value = True
+
+        sqlbackend.connect()
+        assert sqlbackend.create.called is False
+
+        isfile_mock.return_value = False
+        sqlbackend.connect()
+        assert sqlbackend.create.called
+
+        os.path.isfile = isfile_orig
+
 
     @mock.patch('importlib.import_module')
     def test_sqlite_create(self, importlib_mock):
@@ -222,7 +549,7 @@ class TestSQLiteBackend(unittest.TestCase):
         sqlbackend._create_table = mock.MagicMock()
 
         sqlbackend.create(tlmdict=tlmdict)
-        
+
         sqlbackend._create_table.assert_called_with(tlmdict['Packet1'])
 
         os.remove(self.test_yaml_file)
@@ -255,7 +582,7 @@ class TestSQLiteBackend(unittest.TestCase):
 
         sqlbackend._create_table(tlmdict['Packet1'])
         sqlbackend._conn.execute.assert_called_with(
-            'CREATE TABLE IF NOT EXISTS "Packet1" (time DATETIME DEFAULT(STRFTIME(\'%Y-%m-%dT%H:%M:%fZ\', \'NOW\')), col1 INTEGER, SampleTime REAL)'
+            'CREATE TABLE IF NOT EXISTS "Packet1" (time DATETIME DEFAULT(STRFTIME(\'%Y-%m-%dT%H:%M:%fZ\', \'NOW\')), PKTDATA BLOB NOT NULL)'
         )
 
         os.remove(self.test_yaml_file)
@@ -289,9 +616,188 @@ class TestSQLiteBackend(unittest.TestCase):
         pkt_defn = tlmdict['Packet1']
         pkt = tlm.Packet(pkt_defn, bytearray(range(pkt_defn.nbytes)))
 
+        # We can't fully test this call given the modification to the packet
+        # data on insert. Better than nothing I suppose.
         sqlbackend.insert(pkt)
-        sqlbackend._conn.execute.assert_called_with(
-            'INSERT INTO "Packet1" (col1, SampleTime) VALUES (?, ?)', [1, 33752069.10112411]
-        )
+        assert 'INSERT INTO "Packet1" (PKTDATA) VALUES (?)' in sqlbackend._conn.execute.call_args[0]
 
         os.remove(self.test_yaml_file)
+
+    def test_sqlite_query_calldown(self):
+        sqlbackend = db.SQLiteBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        sqlbackend.query('SELECT * FROM table')
+        sqlbackend._conn.execute.assert_called_with('SELECT * FROM table')
+
+    def test_query_return_types(self):
+        sqlbackend = db.SQLiteBackend()
+        sqlbackend._conn = mock.MagicMock()
+        sqlbackend._query = mock.MagicMock()
+
+        # Check that a successful query returns a properly formatted AITDBResult
+        ret_val = [1, 2, 3]
+        query_string = 'select * from table'
+        sqlbackend._query.return_value = ret_val
+        results = sqlbackend.query(query_string)
+        assert isinstance(results, db.AITDBResult)
+        assert results.query == query_string
+        assert results.results == ret_val
+
+        # Check that a failed query returns a properly formatted AITDBResult
+        sqlbackend._query.side_effect = sqlbackend._backend.OperationalError('foo')
+        results = sqlbackend.query(query_string)
+        assert results.query == query_string
+        assert results.errors == ['foo']
+
+    def test_query_packets_calldown(self):
+        sqlbackend = db.SQLiteBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        start = dmc.GPS_Epoch
+        end = dt.datetime.utcnow()
+        packets = [list(tlm.getDefaultDict().keys())[0]]
+
+        sqlbackend.query_packets(packets=packets, start_time=start, end_time=end)
+
+        start = start.strftime(dmc.RFC3339_Format)
+        end = end.strftime(dmc.RFC3339_Format)
+        for i, pkt in enumerate(packets):
+            query = f'SELECT * FROM "{pkt}" WHERE time >= "{start}" AND time <= "{end}" ORDER BY time ASC'
+            assert sqlbackend._conn.execute.call_args[i][0] == query
+
+    def test_query_packets_arg_handling(self):
+        sqlbackend = db.SQLiteBackend()
+        sqlbackend._conn = mock.MagicMock()
+        query_string = 'SELECT * FROM "{}" WHERE time >= "{}" AND time <= "{}" ORDER BY time ASC'
+
+        # Test no packet provided handling
+        #######################################
+        start = dmc.GPS_Epoch
+        end = dt.datetime.utcnow()
+
+        res = sqlbackend.query_packets(start_time=start, end_time=end)
+
+        packets = list(tlm.getDefaultDict().keys())
+        start = start.strftime(dmc.RFC3339_Format)
+        end = end.strftime(dmc.RFC3339_Format)
+        query = query_string.format(packets, start, end)
+
+        for i, pkt in enumerate(packets):
+            query = f'SELECT * FROM "{pkt}" WHERE time >= "{start}" AND time <= "{end}" ORDER BY time ASC'
+            assert sqlbackend._conn.execute.call_args_list[i][0][0] == query
+
+        sqlbackend._conn.reset_mock()
+
+        # Test no start time handling
+        #######################################
+        end = dt.datetime.utcnow()
+
+        packets = [list(tlm.getDefaultDict().keys())[0]]
+
+        sqlbackend.query_packets(packets=packets, end_time=end)
+
+        start = dmc.GPS_Epoch.strftime(dmc.RFC3339_Format)
+        end = end.strftime(dmc.RFC3339_Format)
+        query = query_string.format(packets[0], start, end)
+
+        assert sqlbackend._conn.execute.call_args[0][0] == query
+        sqlbackend._conn.reset_mock()
+
+        # Test no end time handling
+        #######################################
+        packets = [list(tlm.getDefaultDict().keys())[0]]
+
+        sqlbackend.query_packets(packets=packets)
+
+        start = dmc.GPS_Epoch.strftime(dmc.RFC3339_Format)
+        end = dt.datetime.utcnow()
+        query = query_string.format(packets, start, end)
+
+        exec_end_time = dt.datetime.strptime(
+            sqlbackend._conn.execute.call_args[0][0].split('"')[-2],
+            dmc.RFC3339_Format
+        )
+
+        assert (end - exec_end_time).seconds < 1
+        sqlbackend.query_packets()
+
+        # Test bad packet name exception
+        #######################################
+        nose.tools.assert_raises(
+            ValueError,
+            sqlbackend.query_packets,
+            packets=['not_a_valid_packet']
+        )
+
+    def test_query_fail_handling(self):
+        sqlbackend = db.SQLiteBackend()
+        sqlbackend._conn = mock.MagicMock()
+        sqlbackend._query = mock.MagicMock()
+        sqlbackend._query.side_effect = sqlbackend._backend.OperationalError('foo')
+
+        res = sqlbackend.query_packets()
+        for e in res.errors:
+            assert e == 'foo'
+
+    def test_query_success_handling(self):
+        sqlbackend = db.SQLiteBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        res_mock = mock.MagicMock()
+        res_mock.return_value=[
+            ('2020-12-02T00:41:43.199Z', b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'),
+            ('2020-12-02T00:41:44.200Z', b'\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01'),
+            ('2020-12-02T00:41:45.205Z', b'\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02'),
+            ('2020-12-02T00:41:46.211Z', b'\x00\x03\x00\x03\x00\x03\x00\x03\x00\x03'),
+            ('2020-12-02T00:41:47.216Z', b'\x00\x04\x00\x04\x00\x04\x00\x04\x00\x04'),
+            ('2020-12-02T00:41:48.221Z', b'\x00\x05\x00\x05\x00\x05\x00\x05\x00\x05')
+        ]
+
+        sqlbackend._query = res_mock
+
+        res = sqlbackend.query_packets(packets=['1553_HS_Packet'])
+
+        assert isinstance(res, db.AITDBResult)
+        assert res._packets is not None
+
+        res_pkts = list(res.get_packets())
+        assert len(res_pkts) == 6
+        assert isinstance(res_pkts[0], tlm.Packet)
+
+        assert res_pkts[0].Voltage_A == 0
+        assert res_pkts[1].Voltage_A == 1
+        assert res_pkts[2].Voltage_A == 2
+        assert res_pkts[3].Voltage_A == 3
+        assert res_pkts[4].Voltage_A == 4
+        assert res_pkts[5].Voltage_A == 5
+
+    def test_query_packet_time_inclusion(self):
+        sqlbackend = db.SQLiteBackend()
+        sqlbackend._conn = mock.MagicMock()
+
+        ret_data = [
+            ('2020-12-02T00:41:43.199Z', b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'),
+            ('2020-12-02T00:41:44.200Z', b'\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01'),
+            ('2020-12-02T00:41:45.205Z', b'\x00\x02\x00\x02\x00\x02\x00\x02\x00\x02'),
+            ('2020-12-02T00:41:46.211Z', b'\x00\x03\x00\x03\x00\x03\x00\x03\x00\x03'),
+            ('2020-12-02T00:41:47.216Z', b'\x00\x04\x00\x04\x00\x04\x00\x04\x00\x04'),
+            ('2020-12-02T00:41:48.221Z', b'\x00\x05\x00\x05\x00\x05\x00\x05\x00\x05')
+        ]
+        res_mock = mock.MagicMock()
+        res_mock.return_value=ret_data
+        sqlbackend._query = res_mock
+
+        res = sqlbackend.query_packets(packets=['1553_HS_Packet'], yield_packet_time=True)
+
+        assert isinstance(res, db.AITDBResult)
+        assert res._packets is not None
+
+        res_pkts = list(res.get_packets())
+        assert len(res_pkts) == 6
+        assert isinstance(res_pkts[0], tuple)
+
+        for i, test_data in enumerate(ret_data):
+            assert dt.datetime.strptime(ret_data[i][0], dmc.RFC3339_Format) == res_pkts[i][0]
+            assert res_pkts[i][1].Voltage_A == i
+


### PR DESCRIPTION
This is a bit of a sweeping rework to parts of the database APIs to
provide a unification to result formatting. During testing a few issues
were run into specific to the SQLiteBackend implementation that resulted
in a complete rework to the data storage format. These changes are
related enough that I'm grouping them under a single pull request.
Related issues:

Issue #303 - Database API query and results abstraction
Issue #307 - SQLite Backend Simplification
Issue #310 - DB API Sqlite connection and creation handling fails
    to properly cover cases

Add AITDBResult class to provide a minimal wrapper around all database
query results. Any API that executes a query and returns results now
returns an AITDBResult object. Users can access the queries execute, any
errors encountered, and the query results (either raw or as processed
Packets depending on the interface) through this object.

Add a `query_packets` function to the backends. These functions take an
optional list of packet types and start / end times and return
time-ordered Packet objects for all results. This is likely the primary
interface that users and AIT will use to access data in a
backend-agnostic way.

Add a `create_packet_from_result` classmethod to the backends. The
backends use these to parse a given query result item into an AIT
packet. Previously only the Influx backend had a similar function (it is
now marked deprecated). These also provide users a helpful interface
for converting results to packets as part of their custom queries.

Completely rework the SQLite backend storage format to use BLOB to store
packets instead of splitting fields out into individual columns.
Ticket #307 provides an explanation for why this was done. In short,
the SQLite support is really meant for demonstration purposes and to
provide a baseline implementation that other backends can reference.
Users are heavily encouraged to NOT use SQLite as their primary mission
backend. Now seemed like a good time to make this switch given the impact
on the existing code from changes for #303 and the lack of thorough testing
for the previous format and type handling.

Fix the poor SQLiteBackend handling of connect / create and fix the
issue where custom named databases weren't being properly configured.
SQLiteBackend.connect now "connects" to the datastore and checks if the
database previously existed. If not, then the table structure needs
handled. SQLiteBackend.create now only creates tables instead of the
previously incorrect hybrid of functionality.

Resolve #303 
Resolve #307 
Resolve #310 