### PR TITLE
Issue #306 - Support lists in config directory expansion

### DIFF
--- a/ait/core/cfg.py
+++ b/ait/core/cfg.py
@@ -63,9 +63,15 @@ def expandConfigPaths (config, prefix=None, datetime=None, pathvars=None, parame
 
             config[name] = cleaned[0] if len(cleaned) == 1 else cleaned
 
-        elif type(value) is dict:
+        elif isinstance(value, dict):
             param_key = name if parameter_key == '' else parameter_key + '.' + name
             expandConfigPaths(value, prefix, datetime, pathvars, param_key, *keys)
+
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    param_key = name if parameter_key == '' else parameter_key + '.' + name
+                    expandConfigPaths(item, prefix, datetime, pathvars, param_key, *keys)
 
 
 def replaceVariables(path, datetime=None, pathvars=None):

--- a/ait/core/test/test_cfg.py
+++ b/ait/core/test/test_cfg.py
@@ -75,7 +75,17 @@ def test_expandConfigPaths ():
             'desc'    : 'Test expansion of nested dictionaries too',
             'file'    : os.path.join('bin', 'ait-cmd-send'),
             'filename': os.path.join('bin', 'ait-cmd-send'),
-        }
+        },
+        'a list': [
+            {
+                'file'    : os.path.join('bin', 'ait-orbits-in-a-list'),
+                'filename': os.path.join('bin', 'ait-orbits-in-a-list'),
+            },
+            {
+                'file'    : os.path.join('bin', 'ait-cmd-send-in-a-list'),
+                'filename': os.path.join('bin', 'ait-cmd-send-in-a-list'),
+            }
+        ]
     }
     expected = {
         'desc'    : 'Test cfg.expandConfigPaths()',
@@ -85,7 +95,17 @@ def test_expandConfigPaths ():
             'desc'    : 'Test expansion of nested dictionaries too',
             'file'    : os.path.join(prefix, 'bin', 'ait-cmd-send'),
             'filename': os.path.join(prefix, 'bin', 'ait-cmd-send'),
-        }
+        },
+        'a list': [
+            {
+                'file'    : os.path.join(prefix, 'bin', 'ait-orbits-in-a-list'),
+                'filename': os.path.join(prefix, 'bin', 'ait-orbits-in-a-list'),
+            },
+            {
+                'file'    : os.path.join(prefix, 'bin', 'ait-cmd-send-in-a-list'),
+                'filename': os.path.join(prefix, 'bin', 'ait-cmd-send-in-a-list'),
+            }
+        ]
     }
 
     cfg.expandConfigPaths(actual, prefix, None, None, '', 'file', 'filename')


### PR DESCRIPTION
Update the config directory expansion handling to support lists within
dictionary elements. This server rework added elements consisting of
lists of dictionaries, some of which contain elements that could require
path expansion. For example, the GUI plugin looks for static file
directory configuration which likely requires path expansion. These
changes fix the issue in parsing elements of this sort.

Resolve #306 