### PR TITLE
Issue #299 - Update server 0MQ data passing

### DIFF
--- a/ait/core/server/plugins/data_archive.py
+++ b/ait/core/server/plugins/data_archive.py
@@ -75,7 +75,7 @@ class DataArchive(Plugin):
             **kwargs:    any args required for connected to the backend
         """
         try:
-            load = pickle.loads(eval(input_data))
+            load = pickle.loads(input_data)
             uid, pkt = int(load[0]), load[1]
             defn = self.packet_dict[uid]
             decoded = tlm.Packet(defn, data=bytearray(pkt))

--- a/ait/core/server/utils.py
+++ b/ait/core/server/utils.py
@@ -1,0 +1,64 @@
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+# Bespoke Link to Instruments and Small Satellites (BLISS)
+#
+# Copyright 2021, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.
+
+
+import pickle
+
+
+def encode_message(topic, data):
+    """Encode a message for sending via 0MQ
+
+    Given a string topic name and a pickle-able data object, encode and prep
+    the data for sending via `send_multipart`
+
+    Returns a list of the form:
+        [
+            Bytes object of String (UTF-8),
+            Pickled data object
+        ]
+
+    If encoding fails None will be returned.
+
+    """
+    try:
+        enc = [bytes(topic, 'utf-8'), pickle.dumps(data)]
+    except:
+        enc = None
+
+    return enc
+
+
+def decode_message(msg):
+    """Decode a message received via 0MQ
+
+    Given a message received from `recv_multipart`, decode the components.
+
+    Returns a tuple of the form:
+        (
+            UTF-8 string
+            De-pickled data object
+        )
+
+    If decoding fails a tuple of None objects will be returned.
+    """
+    [topic, message] = msg
+
+    try:
+        tpc = topic.decode('utf-8')
+        msg = pickle.loads(message)
+    except:
+        tpc = None
+        msg = None
+
+    return (tpc, msg)

--- a/doc/source/ait.core.server.rst
+++ b/doc/source/ait.core.server.rst
@@ -20,6 +20,7 @@ Submodules
    ait.core.server.plugin
    ait.core.server.server
    ait.core.server.stream
+   ait.core.server.utils
 
 Module contents
 ---------------

--- a/doc/source/ait.core.server.utils.rst
+++ b/doc/source/ait.core.server.utils.rst
@@ -1,0 +1,7 @@
+ait.core.server.utils module
+============================
+
+.. automodule:: ait.core.server.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Update server handling of data passing to use 0MQ's
`[send|recv]_multipart` calls instead of `[send|recv]_string`.

Utilities have been added under ait.core.server.utils for encoding /
decoding messages into the proper format to simplify code throughout.

Various hacks for handling the string-ified data have been removed.

Resolve #299