### PR TITLE
Issue #194 - Add support for seq extensions

### DIFF
--- a/ait/core/bin/ait_seq_decode.py
+++ b/ait/core/bin/ait_seq_decode.py
@@ -16,13 +16,13 @@
 
 '''
 
-usage: ait-seq-decode oco3_seq_SSS_NNN_desc.bin
+usage: ait-seq-decode ait_seq_SSS_NNN_desc.bin
 
 Decodes the given relative time command sequence to text.
 
 Examples:
 
-  $ ait-seq-decode seq/oco3_seq_gps_001_reset.bin
+  $ ait-seq-decode seq/ait_seq_gps_001_reset.bin
 '''
 
 import os
@@ -67,7 +67,7 @@ def main():
         except ValueError:
             raise Exception('Invalid filename "%s": . %s' % (os.path.basename(filename), __doc__))
 
-    sequence = seq.Seq(filename, id=seqid)
+    sequence = seq.createSeq(filename, id=seqid)
 
     if not sequence.validate():
         for msg in sequence.messages:

--- a/ait/core/bin/ait_seq_encode.py
+++ b/ait/core/bin/ait_seq_encode.py
@@ -25,7 +25,7 @@ Encodes the given relative time command sequence to binary.
 
 Examples:
 
-  $ ait-seq-encode seq/oco3_seq_gps_reset_001.txt
+  $ ait-seq-encode seq/ait_seq_gps_reset_001.txt
 '''
 
 import os
@@ -74,7 +74,7 @@ def main():
             except ValueError:
                 raise Exception('Invalid filename "%s": . %s' % (os.path.basename(filename), __doc__))
 
-            sequence = seq.Seq(filename, id=seqid)
+            sequence = seq.createSeq(filename, id=seqid)
 
             if not sequence.validate():
                 for msg in sequence.log.messages:

--- a/ait/core/bin/ait_seq_print.py
+++ b/ait/core/bin/ait_seq_print.py
@@ -15,14 +15,14 @@
 # information to foreign countries or providing access to foreign persons.
 
 '''
-usage: ait-seq-print oco3_seq_SSS_NNN_desc.bin
+usage: ait-seq-print ait_seq_SSS_NNN_desc.bin
 
 Prints the given binary relative time command sequence to standard
 output as text.
 
 Examples:
 
-  $ ait-seq-print seq/oco3_seq_gps_001_reset.bin
+  $ ait-seq-print seq/ait_seq_gps_001_reset.bin
 '''
 
 import os
@@ -67,7 +67,7 @@ def main():
         except ValueError:
             raise Exception('Invalid filename "%s": . %s' % (os.path.basename(filename), __doc__))
 
-    sequence = seq.Seq(filename, id=seqid)
+    sequence = seq.createSeq(filename, id=seqid)
 
     if not sequence.validate():
         for msg in sequence.messages:

--- a/ait/core/seq.py
+++ b/ait/core/seq.py
@@ -26,7 +26,7 @@ import struct
 import sys
 import time
 
-from ait.core import cmd, util
+from ait.core import cmd, log, util
 
 
 def setBit (value, bit, bitval):
@@ -744,3 +744,5 @@ class SeqMsgLog (object):
   def warning (self, msg, pos=None):
     """Logs a warning message pertaining to the given SeqAtom."""
     self.log(msg, 'warning: ' + self.location(pos))
+
+util.__init_extensions__(__name__, globals())


### PR DESCRIPTION
Update seq.py to support extensions. Update all references to `seq.Seq`
to instead use the extension compatible `seq.createSeq`.

Note, for now all other internal seq classes are left along. This means
that extending an internal part of a sequence, such as SeqCmd, isn't
possible without some additional work on the user's part. I'm not sure
that this is a huge issue given the relative simplicity of the calls to
the other classes (so updating wouldn't be much of an issue) and the
perceived likelihood that most seq.py extensions will be to change
encoding / decoding.

Resovle #194