### PR TITLE
Issue #335 - Make Seq sequence id optional on initialization

### DIFF
--- a/ait/core/seq.py
+++ b/ait/core/seq.py
@@ -54,7 +54,7 @@ class Seq (object):
     self.pathname  = pathname
     self.cmddict   = cmddict or cmd.getDefaultCmdDict()
     self.crc32     = None
-    self.seqid     = int(id)
+    self.seqid     = id
     self.lines     = [ ]
     self.header    = { }
     self.version   = version


### PR DESCRIPTION
Seq no longer tries to cast the sequence `id` argument on initialization so
creating a new Seq without an id is valid. This is useful when creating
a Seq from a binary encoded sequence file in which the sequence id is
encoded. By default, it will parse this out for you.

Resolve #335