### PR TITLE
Issue #339 - Document Packet / Field naming constraints

### DIFF
--- a/doc/source/telemetry_intro.rst
+++ b/doc/source/telemetry_intro.rst
@@ -89,6 +89,11 @@ With the :class:`ait.core.tlm.Packet` object we can check each of those values a
 
 ----
 
+.. warning::
+
+   Packet and Field names should conform with Python's variable name constraints. This is not enforced by the dictionary handling or validation but failing to do so will result in potentially unexpected behavior or errors when attempting to reference attributes depending on use cases. When in doubt, open the Python REPL and try to use your Packet / Field name as a variable name. If Python complains then you should change that value.
+
+
 !Packet
 -------
 


### PR DESCRIPTION
Update telemetry documentation with a warning that all Packet / Field
names should be valid Python variable names to avoid any issues when
using the toolkit.

Note, even though this can (sometimes) be worked around and it's not
necessarily always an issue in both the Packet and Field cases, I think
it's safer to just warn against any of this and avoid the overhead of
trying to debug various issues here.

Resolve #339 