### PR TITLE
Issue #345 - Document 64-bit integer limitation in GUI

### DIFF
--- a/doc/source/telemetry_intro.rst
+++ b/doc/source/telemetry_intro.rst
@@ -228,7 +228,11 @@ name:
     A **string** denoting the name of this field in the packet. Note: Do not use the name "time". "time" is a reserved name used in the backend databases for recording the time of entries. To avoid conflicts of this nature, you should avoid using generic names or prepend names with a subsystem identifier.
 
 type:
-    A **string** specifying the data type for the section of the packet in which this field is located. You can see all the valid primitive types that will be accepted here by looking at ``ait.dtype.PrimitiveTypes``. Arrays of types are also supported, e.g. ``MSB_U16[32]``.  You can see examples of how *type* is used in the `Example Telemetry Packet Definition`_ section.
+    A **string** specifying the data type for the section of the packet in which this field is located. You can see all the valid primitive types that will be accepted here by looking at ``ait.dtype.PrimitiveTypes``. You can see examples of how *type* is used in the `Example Telemetry Packet Definition`_ section.
+
+    .. note::
+    
+       64-bit integer types are supported by AIT's core libraries but these will not function as expected in the monitoring UI due to limitations with JavaScript and its internal representation of numbers. This does not affect complex types like ``Time64``. It is recommended that you split 64-bit integer fields into separates bytes / words if you plan to display that entire field in the GUI. If you have questions or need help with a work-around for this limitation please reach out to the development team.
 
 units (optional):
     a **string** specifying the units of the derived field's value.


### PR DESCRIPTION
Add a note to the `type` attribute of the telemetry Field definition
documentation elaborating on the issues with 64-bit integers being
displayed by the frontend due to JavaScript's approach to number
representation.

Resolve #345