### PR TITLE
Add historical query support to the OpenMCT plugin

### DIFF
--- a/ait/core/dmc.py
+++ b/ait/core/dmc.py
@@ -241,6 +241,16 @@ def totalSeconds(td):
 
     return ts
 
+def rfc3339StrToDatetime(datestr):
+    """rfc3339StrToDatetime(str) -> datetime
+
+    Returns a datetime object build from the RFC3339-formatted string.
+    Care is taken to ensure that the UTC timezone is preserved.
+    """
+    if datestr is None:
+        return None
+    return datetime.datetime.strptime(datestr, RFC3339_Format).replace(tzinfo=datetime.timezone.utc)
+
 
 class UTCLeapSeconds(object):
     def __init__(self):

--- a/ait/core/test/test_db.py
+++ b/ait/core/test/test_db.py
@@ -244,7 +244,7 @@ class TestInfluxDBBackend(unittest.TestCase):
         packets = ', '.join(packets)
         start = start.strftime(dmc.RFC3339_Format)
         end = end.strftime(dmc.RFC3339_Format)
-        query = f"SELECT * FROM {packets} WHERE time >= '{start}' AND time <= '{end}'"
+        query = f"SELECT * FROM \"{packets}\" WHERE time >= '{start}' AND time <= '{end}'"
 
         assert sqlbackend._conn.query.call_args[0][0] == query
 
@@ -263,7 +263,7 @@ class TestInfluxDBBackend(unittest.TestCase):
         packets = ', '.join([f'"{i}"' for i in tlm.getDefaultDict().keys()])
         start = start.strftime(dmc.RFC3339_Format)
         end = end.strftime(dmc.RFC3339_Format)
-        query = f"SELECT * FROM {packets} WHERE time >= '{start}' AND time <= '{end}'"
+        query = f"SELECT * FROM \"{packets}\" WHERE time >= '{start}' AND time <= '{end}'"
 
         assert sqlbackend._conn.query.call_args[0][0] == query
         sqlbackend._conn.reset_mock()
@@ -277,7 +277,7 @@ class TestInfluxDBBackend(unittest.TestCase):
         packets = ', '.join([f'"{i}"' for i in tlm.getDefaultDict().keys()])
         start = dmc.GPS_Epoch.strftime(dmc.RFC3339_Format)
         end = end.strftime(dmc.RFC3339_Format)
-        query = f"SELECT * FROM {packets} WHERE time >= '{start}' AND time <= '{end}'"
+        query = f"SELECT * FROM \"{packets}\" WHERE time >= '{start}' AND time <= '{end}'"
 
         assert sqlbackend._conn.query.call_args[0][0] == query
         sqlbackend._conn.reset_mock()
@@ -419,7 +419,8 @@ class TestInfluxDBBackend(unittest.TestCase):
         assert isinstance(res_pkts[0], tuple)
 
         for i, test_data in enumerate(ret_data[0][1]):
-            assert dt.datetime.strptime(test_data['time'], dmc.RFC3339_Format) == res_pkts[i][0]
+
+            assert dmc.rfc3339StrToDatetime(test_data['time']) == res_pkts[i][0]
             assert res_pkts[i][1].Voltage_A == i
 
     @mock.patch('importlib.import_module')
@@ -798,6 +799,6 @@ class TestSQLiteBackend(unittest.TestCase):
         assert isinstance(res_pkts[0], tuple)
 
         for i, test_data in enumerate(ret_data):
-            assert dt.datetime.strptime(ret_data[i][0], dmc.RFC3339_Format) == res_pkts[i][0]
+            assert dmc.rfc3339StrToDatetime(ret_data[i][0]) == res_pkts[i][0]
             assert res_pkts[i][1].Voltage_A == i
 

--- a/doc/source/plugin_openmct.rst
+++ b/doc/source/plugin_openmct.rst
@@ -20,14 +20,14 @@ Activating the OpenMCT Plugin
 Update your AIT configuration file :ref:`config.yaml <Config_Intro>` to add the AITOpenMctPlugin in the 'server:plugins:' section.
 
 .. _Ait_openmct_port:
-The plugin's 'port' value defaults to 8082, but can be overridden in the configuration.  If something other than the default is used, you will also need to include this in
+The plugin's 'service_port' value defaults to 8082, but can be overridden in the configuration.  If something other than the default is used, you will also need to include this in
 the OpenMCT frameworks's setup configuration.
 
 Currently, the server is assumed to run on 'localhost'.
 
 .. _Plugin_config:
 
-Example configuration:
+Example configuration with realtime telemetry only:
 
 .. code-block:: none
 
@@ -36,7 +36,37 @@ Example configuration:
             name: ait.core.server.plugins.openmct.AITOpenMctPlugin
             inputs:
                 - telem_stream
-            port: 8082
+            service_port: 8082
+            debug_enabled: False
+            database_enabled: False
+
+
+
+Example configuration with realtime and historical support:
+
+.. code-block:: none
+
+    plugins:
+        - plugin:
+            name: ait.core.server.plugins.openmct.AITOpenMctPlugin
+            inputs:
+                - telem_stream
+            service_port: 8082
+            debug_enabled: False
+            database_enabled: True
+            datastore: ait.core.db.InfluxDBBackend
+
+**Note:**
+When database is enabled, your AIT configuration file will also need to include a *database* section:
+
+.. code-block:: none
+
+    database:
+         host: localhost
+         port: 8086
+         dbname: ait
+         un: <username>
+         pw: <password>
 
 
 

--- a/openmct/ait_cfg_section.yaml
+++ b/openmct/ait_cfg_section.yaml
@@ -9,6 +9,8 @@
             - plugin:
                 name: ait.core.server.plugins.openmct.AITOpenMctPlugin
                 inputs:
-                    - log_stream
                     - telem_stream
-                port: 8082
+                service_port: 8082
+                debug_enabled: False
+                database_enabled: True
+                datastore: ait.core.db.InfluxDBBackend

--- a/openmct/ait_integration.js
+++ b/openmct/ait_integration.js
@@ -22,11 +22,6 @@
  * https://github.com/nasa/openmct-tutorial
  *
  * Important Notes and Setup:
- *  - The current AIT backend implementation does not support the OpenMCT
- *    historical data query implementation. To work around this, ensure
- *    that the historical data endpoint in OpenMCT returns an empty
- *    dataset for any queried point. The AITHistoricalTelemetryPlugin
- *    function calls the default OpenMCT Tutorial historical endpoint.
  *  - Include the below code into OpenMCT by including this file in the
  *    example index.html file and installing the various components.
  *
@@ -220,8 +215,6 @@ function AITIntegration(config) {
 
 //Historical telemetry
 function AITHistoricalTelemetryPlugin() {
-
-    const historicalQueryEnabled = false;
 
     return function install (openmct) {
         let provider = {


### PR DESCRIPTION
The original version of the AIT OpenMct plugin supported realtime telemetry only.
This PR adds historial queries - which is supported by telemetry stored in a database.
The layer uses the newer AIT Database abstraction, and so should work with any supported Database implementation. 

Fixes #302 