### PR TITLE
Issue #354 - Rework table support

### DIFF
--- a/ait/core/bin/ait_table_decode.py
+++ b/ait/core/bin/ait_table_decode.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-
+#
 # Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
 # Bespoke Link to Instruments and Small Satellites (BLISS)
 #
-# Copyright 2016, by the California Institute of Technology. ALL RIGHTS
+# Copyright 2021, by the California Institute of Technology. ALL RIGHTS
 # RESERVED. United States Government Sponsorship acknowledged. Any
 # commercial use must be negotiated with the Office of Technology Transfer
 # at the California Institute of Technology.
@@ -14,17 +14,11 @@
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
 
-'''
-usage: ait-table-decode --fswtabdict config/table.yaml --tabletype targets --binfile /Users/ays/targets.bin
-
-Decodes the given FSW binary table to text.
-
-Examples:
-
-  $ ait-table-decode --fswtabdict config/table.yaml --tabletype targets --binfile /Users/ays/targets.bin
-'''
+"""Decode AIT FSW table binaries"""
 
 import argparse
+import os.path
+import sys
 
 from ait.core import log, table
 
@@ -33,45 +27,52 @@ def main():
     log.begin()
 
     parser = argparse.ArgumentParser(
-         description=__doc__,
-         formatter_class=argparse.RawDescriptionHelpFormatter)
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
 
-    # Add optional command line arguments
-    parser.add_argument('--binfile', default=None, required=True)
-    parser.add_argument('--fswtabdict', default=None, required=True)
-    parser.add_argument('--tabletype', default=None, required=True)
-    parser.add_argument('--verbose', action='store_true', default=False)
-    parser.add_argument('--version', default=0, type=int)
+    parser.add_argument("in_file", help="Input file path")
+    parser.add_argument("--out_file", default=None, help="Output file path")
+    parser.add_argument("--raw", action="store_true", help="Decode columns into raw values without enumerations")
 
-    # Get command line arguments
-    args = vars(parser.parse_args())
-    binfile       = args['binfile']
-    dictpath      = args['fswtabdict']
-    tabletype     = args['tabletype']
-    verbose       = args['verbose']
-    version       = args['version']
+    args = parser.parse_args()
 
+    file_in = open(args.in_file, "rb")
+    out_path = (
+        args.out_file
+        if args.out_file is not None
+        else f"{os.path.splitext(args.in_file)[0]}_decoded.txt"
+    )
 
-    # If arguments include fswtabledict, try to load it
-    if dictpath is not None:
-        dictCache = table.FSWTabDictCache(filename=dictpath)
+    # Extract the table upload type (byte 0) from the binary so we can
+    # locate the table definition that we need.
+    uptype = int.from_bytes(file_in.read(1), byteorder='big')
+    file_in.seek(0)
+    fswtabdict = table.getDefaultFSWTabDict()
+    pos_defn = [map[0] for map in fswtabdict.items() if map[1].uptype == uptype]
 
-        try:
-            filename = dictCache.filename
-            fswtabdict = table.FSWTabDict(filename)
-        except IOError as e:
-            msg = 'Could not load table dictionary "%s": %s'
-            log.error(msg, filename, str(e))
-    else:  # Grab default table dictionary
-        fswtabdict  = table.getDefaultFSWTabDict()
+    if len(pos_defn) != 1:
+        log.error(
+            f"Table upload type {uptype} not found in table dictionary. Stopping ..."
+        )
+        sys.exit(1)
 
-    # Check if fswtabddict exists, if so continue processing
-    if fswtabdict is not None:
-        # Write out the table file using the command dictionary
-        table.writeToText(fswtabdict, tabletype, binfile, verbose, version)
+    tbldefn = fswtabdict[pos_defn[0]]
+    decoded = tbldefn.decode(file_in=file_in, raw=args.raw)
+
+    out_file = open(out_path, "w")
+
+    # Output our header values in comments so the table can be re-encoded easily
+    hdr_row = decoded[0]
+    for defn, val in zip(tbldefn.fswheaderdefns, hdr_row):
+        print(f"# {defn.name}={val}", file=out_file)
+
+    for row in decoded[1:]:
+        print(tbldefn.delimiter.join(map(str, row)), file=out_file)
+
+    out_file.close()
 
     log.end()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/ait/core/data/table_schema.json
+++ b/ait/core/data/table_schema.json
@@ -27,7 +27,7 @@
                 "items": {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["fswcolumn", "name", "format", "type"],
+                    "required": ["fswcolumn", "name", "type"],
                     "properties": {
                         "fswcolumn": {
                             "type": "string"
@@ -38,32 +38,12 @@
                         "desc": {
                             "type": "string"
                         },
-                        "format": {
-                            "type": "string"
-                        },
-                        "units": {
-                            "type": "string"
-                        },
                         "type": {
                             "type": "string"
                         },
-                        "bytes": {
-                            "anyOf": [
-                                {
-                                    "type": "integer"
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": ["@prev"]
-
-                                },
-                                {
-                                    "type": "array",
-                                    "maxItems": 2,
-                                    "items": { "type": "integer" }
-                                }
-                              ],
-                            "description": "TODO: Need to update the min/max when NOT a list"
+                        "enum": {
+                            "type": "object",
+                            "description": "TODO: Does not check valid enumeration"
                         }
                     }
                 }
@@ -73,7 +53,7 @@
                 "items": {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["fswcolumn", "name", "format", "type"],
+                    "required": ["fswcolumn", "name", "type"],
                     "properties": {
                         "fswcolumn": {
                             "type": "string"
@@ -84,32 +64,8 @@
                         "desc": {
                             "type": "string"
                         },
-                        "format": {
-                            "type": "string"
-                        },
-                        "units": {
-                            "type": "string"
-                        },
                         "type": {
                             "type": "string"
-                        },
-                        "bytes": {
-                            "anyOf": [
-                                {
-                                    "type": "integer"
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": ["@prev"]
-
-                                },
-                                {
-                                    "type": "array",
-                                    "maxItems": 2,
-                                    "items": { "type": "integer" }
-                                }
-                              ],
-                            "description": "TODO: Need to update the min/max when NOT a list"
                         },
                         "enum": {
                             "type": "object",

--- a/config/table.yaml
+++ b/config/table.yaml
@@ -4,7 +4,7 @@
 # datatype, units, and the maximum length for that column.
 
 - !FSWTable
-  name: response
+  name: TestTable
   delimiter: ","
   uptype: 1
   size: 18

--- a/config/table.yaml
+++ b/config/table.yaml
@@ -7,56 +7,38 @@
   name: response
   delimiter: ","
   uptype: 1
-  size: 8224
+  size: 18
   header:
     - !FSWColumn
-      name: HEADER_COLUMN_ONE
-      desc: The first column in our header
-      format: "%x"
-      units: none
-      type:  MSB_U16
-      bytes: [0,1]
+      name: uptype
+      desc: This table's `uptype` field for use when decoding
+      type: U8
 
     - !FSWColumn
       name: HEADER_COLUMN_TWO
       desc: The second column in our header
-      format: "%u"
-      units: none
       type:  U8
-      bytes: 2
 
     - !FSWColumn
       name: HEADER_COLUMN_THREE
       desc: The third column in our header
-      format: "%u"
-      units: none
       type:  U8
-      bytes: 3
 
   columns:
     - !FSWColumn
       name: COLUMN_ONE
       desc: First FSW Table Column
-      format: "%u"
-      units: none
       type:  MSB_U16
-      bytes: [0,1]
 
     - !FSWColumn
       name: COLUMN_TWO
       desc: Second FSW Table Column
-      format: "%u"
-      units: none
       type:  MSB_U16
-      bytes: [2,3]
 
     - !FSWColumn
       name: COLUMN_THREE
       desc: Third FSW Table Column
-      format: "%u"
-      units: none
       type:  U8
-      bytes: 4
       enum:
         0: TEST_ENUM_0
         1: TEST_ENUM_1

--- a/doc/source/c_and_dh_intro.rst
+++ b/doc/source/c_and_dh_intro.rst
@@ -1,5 +1,5 @@
-Introduction to Command & Data Handling Tables and Products
-===========================================================
+Onboard Tables and Products
+===========================
 
 The `ait.core.table` module provides interfaces for encoding and decoding flight software tables to and from text and binary.
 
@@ -7,27 +7,114 @@ The flight software table formats are defined in YAML and usually stored in a co
 
 .. code-block:: yaml
 
-   --- !FSWTable
-   name: OurTable
-   delimiter: ","
-   # other config
+    - !FSWTable
+      name: TestTable
+      delimiter: ","
+      uptype: 1
+      size: 18
+      header:
+        - !FSWColumn
+          name: uptype
+          desc: This table's `uptype` field for use when decoding
+          type: U8
 
-   header:
-     - !FSWColumn
-       name: FIRST_HEADER_COLUMN
-       # other header column config
+        - !FSWColumn
+          name: HEADER_COLUMN_TWO
+          desc: The second column in our header
+          type:  U8
 
-     - !FSWColumn
-       name: SECOND_HEADER_COLUMN
-       # other header column config
+        - !FSWColumn
+          name: HEADER_COLUMN_THREE
+          desc: The third column in our header
+          type:  U8
 
-   columns:
-     - !FSWColumn
-       name: FIRST_COLUMN
-       # other column config
+      columns:
+        - !FSWColumn
+          name: COLUMN_ONE
+          desc: First FSW Table Column
+          type:  MSB_U16
 
-     - !FSWColumn
-       name: SECOND_COLUMN
-       # other column config
+        - !FSWColumn
+          name: COLUMN_TWO
+          desc: Second FSW Table Column
+          type:  MSB_U16
 
-There are a number of helper scripts for encoding/decoding flight software tables and for uploading tables. Checkout the :doc:`Command Line Intro <command_line>` page for additional information on what utilities are available. Each utility script provides information on its interfaces via **help** documentation.
+        - !FSWColumn
+          name: COLUMN_THREE
+          desc: Third FSW Table Column
+          type:  U8
+          enum:
+            0: TEST_ENUM_0
+            1: TEST_ENUM_1
+            2: TEST_ENUM_2
+            3: TEST_ENUM_3
+
+
+AIT Core's table support attempts to cover a baseline use case that demonstrates helpful functionality and which project's will hopefully find useful. However, much like Command encoding, it's very likely that projects will need to adapt Core table classes and utilities to meet their needs. We'll discuss the components of table configuration, how Core uses / exposes them by default, and how to customize for project-specific use cases.
+
+
+Default Table Handling
+----------------------
+
+The default table handling assumes a few things discussed below. It's likely this won't be exactly what your project expects. We'll cover adaptations in a second.
+
+- An encoded table is always a fixed size. This size (in bytes) is called out in the **size** attribute of a **!FSWTable**. When encoding a table, if the resulting binary blob is less than the **size** specified it is zero padded. If it's larger, it fails. 
+- Text versions of a table are "delimiter separated files" where the **delimiter** attribute of a **!FSWTable** specifies that is.
+- Tables always have a header and a table-type-specific-identifier is always encoded as the first byte. This value is expected to match the **uptype** specified on one of the **!FSWTable** definitions.
+
+Encoding a row in a table (including the header) is done by encoding a column's value according to the **type** specified for that **!FSWColumn**. Decoding is the inverse, decoding a slice of that table's data according to the **type** specified for that **!FSWColumn**.
+
+
+Customizing
+-----------
+
+Project-specific adaptation focuses around four main elements:
+
+- :class:`ait.core.table.FSWTabDefn` handles encoding / decoding of tables (via :func:`ait.core.table.FSWTabDefn.encode` and :func:`ait.core.table.FSWTabDefn.decode` respectively).
+- :class:`ait.core.table.FSWColDefn` handles encoding / decoding of columns. 
+- The CLI utilities **ait-table-encode** and **ait-table-decode**.
+
+:class:`ait.core.table.FSWColDefn` encoding and decoding are largely wrappers around the Core :mod:`ait.core.dtype` functionality for doing the same. Unless you want to completely change how data types are dealt with in your tables you probably won't need to customize **FSWColDefn**. The CLI utilities **ait-table-[encode|decode]** are both minimal wrappers around calls to :class:`ait.core.table.FSWTabDefn` encode and decode functions. They're mostly boilerplate for handling arguments, checking file paths, etc., and can be easily rewritten to serve your projects use cases.
+
+:class:`ait.core.table.FSWTabDefn` handles the heavy lifting via :func:`ait.core.table.FSWTabDefn.encode` and :func:`ait.core.table.FSWTabDefn.decode`. The interfaces for these functions are generic (taking only **\*\*kwargs**) so users can define the interface in nearly whatever form they'd like. Creating an extension of **FSWTabDefn** and overwriting the encode and decode functions is likely the minimum that your project will need.
+
+----
+
+
+!FSWTable
+---------
+
+name:
+    A **string** name for this table.
+
+delimiter:
+    A **string** denoting the column separator for this table.
+
+uptype:
+    A table-unique identifier.
+
+size:
+    The **exact** size of an encoded version of this table in bytes.
+
+header:
+    A **list** of **!FSWColumn** entries defining the structure of the table's header.
+
+columns:
+    A **list** of **!FSWColumn** entries defining the structure of a row of table data.
+
+
+!FSWColumn
+----------
+
+name:
+    A **string** name for this column.
+
+type:
+    A :mod:`ait.core.dtype`-defined data type specifying the format of this column.
+
+desc (optional):
+    A **string** for providing a description of the column.
+
+enum (optional):
+    A mapping of column values to human-readable enumeration values.
+

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,7 +23,7 @@ Visit the :doc:`Installation and Environment Configuration <installation>` guide
    limits_intro
    Database API <databases>
    Extensions <extensions>
-   Command & Data Handling Tables <c_and_dh_intro>
+   Onboard Tables <c_and_dh_intro>
    bsc_intro
    plugin_openmct
 


### PR DESCRIPTION
Rework Core table support to provide users with more consistent and
understandable feature set. Table encoding / decoding functionality has
been (hopefully) simplified via simpler, more flexible APIs, extraction
of hardcoded functionality, and leveraging of other Core functionality
such as dtype.py where possible.

Table encoding and decoding APIs have been cleaned up and made more
flexible so users can pass inputs in expected formats. Some
functionality has been extracted out of table.py into the encode /
decode CLI scripts (where it arguably belonged to begin with) in an
effort to keep Core functionality and abstractions cleaner. For example,
writing a decoded table to a file is no longer a requirement as part of
table decoding.

Column field handling now uses date type information for encoding /
decoding. This maintains consistency with the rest of the toolkit and
will allow easier extension of toolkit functionality when Extension
support is added to table.py.

Encode / decode CLI scripts have been rewritten. Their argument
structures have been simplified in the process.

The default table configuration formation and table.yaml file have been
simplified. A number of attributes have been removed from the dictionary
structures since they weren't supported by the toolkit anyway.