### PR TITLE
Add "core.seq" to extensions documentation

### DIFF
--- a/doc/source/extensions.rst
+++ b/doc/source/extensions.rst
@@ -51,4 +51,4 @@ Looks like it's working as we expect!
 What else can we extend?
 ------------------------
 
-AIT lets you add extensions for any class found in the `core.cmd <https://ait-core.readthedocs.io/en/latest/ait.core.cmd.html>`_, `core.tlm <https://ait-core.readthedocs.io/en/latest/ait.core.tlm.html>`_, `core.evr <https://ait-core.readthedocs.io/en/latest/ait.core.evr.html>`_, and `core.limits <https://ait-core.readthedocs.io/en/latest/ait.core.limits.html>`_ modules.
+AIT lets you add extensions for any class found in the `core.cmd <https://ait-core.readthedocs.io/en/latest/ait.core.cmd.html>`_, `core.tlm <https://ait-core.readthedocs.io/en/latest/ait.core.tlm.html>`_, `core.evr <https://ait-core.readthedocs.io/en/latest/ait.core.evr.html>`_, `core.limits <https://ait-core.readthedocs.io/en/latest/ait.core.limits.html>`_, and `core.seq <https://ait-core.readthedocs.io/en/latest/ait.core.seq.html>`_ modules.


### PR DESCRIPTION
**Included in this PR:**
- [X] Added "core.seq" to extensions documentation.

**Refs:**
* [issue 362](https://github.com/NASA-AMMOS/AIT-Core/issues/362)