### PR TITLE
Append 'extensions' map to flattened config map

### DIFF
--- a/ait/core/cfg.py
+++ b/ait/core/cfg.py
@@ -355,7 +355,15 @@ class AitConfig(object):
 
         if self._config is not None:
             keys = "default", self._platform, self._hostname
+
+            extensions_map = None
+            if 'extensions' in self._config:
+                extensions_map = self._config['extensions']
+
             self._config = flatten(self._config, *keys)
+
+            if extensions_map:
+                self._config['extensions'] = extensions_map
 
             # on reload, if pathvars have not been set, we want to start
             # with the defaults, add the platform and hostname, and

--- a/ait/core/cmd.py
+++ b/ait/core/cmd.py
@@ -551,9 +551,12 @@ def YAMLCtor_include(loader, node):  # noqa
     return data
 
 
+def init_ext():
+    util.__init_extensions__(__name__, globals())
+
 yaml.add_constructor("!include", YAMLCtor_include)
 yaml.add_constructor("!Command", YAMLCtor_CmdDefn)
 yaml.add_constructor("!Argument", YAMLCtor_ArgDefn)
 yaml.add_constructor("!Fixed", YAMLCtor_ArgDefn)
 
-util.__init_extensions__(__name__, globals())
+init_ext()

--- a/tests/ait/core/test_cfg.py
+++ b/tests/ait/core/test_cfg.py
@@ -293,3 +293,20 @@ def test_AitConfig():
 
         config.reload()
         assert_AitConfig(config, path, filename)
+
+def test_extensions():
+    extendee = 'ait.core.cmd.Cmd'
+    extendor = 'tests.ait.core.test_cfg.TestCmd'
+    cfg_yml = YAML()
+
+    cfg_yml += f"""extensions:
+        {extendee}: {extendor}"""
+    
+    config = cfg.AitConfig(data=cfg_yml)
+    extensions = config.get('extensions', False)
+    assert extensions
+    assert extendee in extensions
+    assert extensions.get(extendee) == extendor
+    
+class TestCmd():
+    pass

--- a/tests/ait/core/test_extensions.py
+++ b/tests/ait/core/test_extensions.py
@@ -1,0 +1,78 @@
+import os, sys, yaml, platform, pytest, logging
+
+import ait
+from ait.core import cfg, cmd, util
+
+@pytest.fixture()
+def test_dict():
+    CMDDICT_TEST = """
+- !Command
+  name:      SEQ_ENABLE_DISABLE
+  opcode:    0x0042
+  arguments:
+    - !Argument
+      name:  sequence_id
+      type:  MSB_U16
+      bytes: [0, 1]
+
+    - !Argument
+      name:  enable
+      type:  U8
+      bytes: 2
+      enum:
+        0: DISABLED
+        1: ENABLED
+"""
+    yield cmd.CmdDict(CMDDICT_TEST)
+
+@pytest.fixture(scope='module')
+def extended_config_yaml():
+    extendee = 'ait.core.cmd.Cmd'
+    extendor = 'tests.ait.core.test_extensions.TruthyCmd'
+    cfg=f"""
+    default:    
+        leapseconds:
+            filename: leapseconds.dat
+
+    {sys.platform}:
+        ISS:
+            bticard: 6
+
+    {platform.node().split(".")[0]}:
+        ISS:
+            apiport: 1234
+
+    extensions:
+        {extendee}: {extendor}
+
+    """
+    return cfg
+
+@pytest.fixture(scope='module')
+def cfg_from_string(extended_config_yaml):
+    def tempFile():    
+        from tests.ait.core import TestFile 
+        with TestFile(data=extended_config_yaml) as filename:
+            config = cfg.AitConfig(filename)
+            config.reload()
+        return config
+    old_cfg = ait.config
+    ait.config = tempFile()
+    cmd.init_ext()
+    yield
+    ait.config = old_cfg
+
+@pytest.fixture
+def opNames(test_dict):
+    names = [i.name for i in test_dict.opcodes.values()]
+    return names 
+    
+class TruthyCmd(cmd.Cmd):
+    def encode(self):
+        return True
+
+def test_extensions(cfg_from_string, test_dict, opNames):
+    op = test_dict.create(opNames[0],0,0)
+    truthy_encode = op.encode()
+    assert isinstance(truthy_encode, bool)
+    assert truthy_encode


### PR DESCRIPTION
Append 'extensions' map to flattened config map.

Fixes bug where the extensions map would be deleted from config map.
This prevented extensions from instantiating.

# Issue
Minimum working example of extension programming as per Read the Docs tutorial does not work. 
Usecase for SunRISE configuration extension does not work either.

# Impact
This issue is mission critical.
This renders the extensions system unusable.
This directly impacts SunRISE and its custom encoders.

# Reproduction of Issue
Replicated by attempting the extensions tutorial on read the docs. 
The extension will never load, the custom class never instantiated, and instead, the default ait.core.cmd.Cmd class will be instantiated.

# Symptoms and Trace

## Runtime
The following log should appear, but does not:
```
2021-12-28T20:17:42.730 | INFO     | Replacing ait.core.cmd.Cmd with custom extension: ait.core.newCmd.NewCmd
```
## util.py 

### __init__extensions
    - Should at some point instantiate extension command.

#### createFunc closure
   - calls `extensions = ait.config.get("extensions", None)`
   - ait.config.get("extensions", None) always returns None.

## cfg.py 
   - Should at some point be able to find 'extensions' in config map.

### AitConfig
   - Should read yaml configuration and make the 'extensions' map available.
   
#### AitConfig.get
   - AitConfig.get never finds 'extensions' in config map
   
#### AitConfig.reload
   - 'extensions' is contained in self._config, as soon as the yaml is loaded.
   - A call to the 'flatten' method is made that mutates the config map: 
       `self._config = flatten(self._config, #keys)`
        where `keys = "default", self._platform, self._hostname`
   - After the flatten call is made, 'extensions' is no longer bound to self._config and is garbage collected. 
   - This is the root cause of failure. 
   
##### flatten
   - Keys from self._config dictionary are popped.
   - Calls to merge are made to produce the flat map using these popped keys
   - The self._config map is nonempty once the merge loop finishes.
   - The 'extension' map is still contained in self._config that was passed in, but not in the flat map that will be returned to replace self._config
   - The 'extension' map was never popped and merged into the flat map since 'extensions' is not contained in the `*keys` argument.
   - The function returns and the 'extension' map is garbage collected.
   - This function is not directly responsible for the issue, since it can not insert the 'extensions' map in a way that satisfies the rest of the program.

# Attempted Solutions

## Add 'extensions' to `keys = "default", self._platform, self._hostname`
No variation of this will work since util.py expects to find an 'extensions' map, and not its flattened elements.

## Save 'extensions' map, and append it to the flattened map in AitConfig.reload
```
   extensions_map = self._config['extensions']
   self._config = flatten(self._config, #keys)
   self._config['extensions'] = extensions_map
```
   This attempt works.
   The 'extensions' map is essentially bolted back onto self._config
   A check to see if the 'extension' block is even in the YAML file was added.


## Solution Quick Test 
- AitConfig.get finds the 'extensions' map
- Util.py is satisfied with the 'extensions' map.
- The correct log message appears on startup.
- The extension is correctly called during usage.

## Automated Test 
- Automated test that:
  - Loads a config with extensions
  - Reloads extensions
  - Verifies if custom encoder was successfully used.