### PR TITLE
Add try except when attempting to pack opcode into struct.

### DIFF
--- a/ait/core/cmd.py
+++ b/ait/core/cmd.py
@@ -241,7 +241,13 @@ class Cmd(object):
         52050J, Section 3.2.3.4).  This leaves 53 words (106 bytes) for
         the command itself.
         """
-        opcode = struct.pack(">H", self.defn.opcode)
+        try:
+            opcode = struct.pack(">H", self.defn.opcode)
+        except:
+            msg = f"The opcode: {hex(self.defn.opcode)} for command {self.name} "
+            msg += "does not fit in an unsigned int. Check your Cmd Dictionary."
+            raise ValueError(msg)
+            
         offset = len(opcode)
         size = max(offset + self.defn.argsize, pad)
         encoded = bytearray(size)


### PR DESCRIPTION
This is intended to help the end user diagnose typos in their command dictionaries.

The default error message is not descriptive enough for the user to quickly find their error.
Enables concise and useful failures logs for smoke testing dictionaries.

