### PR TITLE
Issue-392 Append 'extensions' map to flattened config map.

### DIFF
--- a/ait/core/cfg.py
+++ b/ait/core/cfg.py
@@ -355,7 +355,15 @@ class AitConfig(object):
 
         if self._config is not None:
             keys = "default", self._platform, self._hostname
+
+            extensions_map = None
+            if 'extensions' in self._config:
+                extensions_map = self._config['extensions']
+
             self._config = flatten(self._config, *keys)
+
+            if extensions_map:
+                self._config['extensions'] = extensions_map
 
             # on reload, if pathvars have not been set, we want to start
             # with the defaults, add the platform and hostname, and

--- a/ait/core/cmd.py
+++ b/ait/core/cmd.py
@@ -551,9 +551,13 @@ def YAMLCtor_include(loader, node):  # noqa
     return data
 
 
+def init_ext():
+    util.__init_extensions__(__name__, globals())
+
+
 yaml.add_constructor("!include", YAMLCtor_include)
 yaml.add_constructor("!Command", YAMLCtor_CmdDefn)
 yaml.add_constructor("!Argument", YAMLCtor_ArgDefn)
 yaml.add_constructor("!Fixed", YAMLCtor_ArgDefn)
 
-util.__init_extensions__(__name__, globals())
+init_ext()

--- a/tests/ait/core/test_cfg.py
+++ b/tests/ait/core/test_cfg.py
@@ -293,3 +293,20 @@ def test_AitConfig():
 
         config.reload()
         assert_AitConfig(config, path, filename)
+
+def test_extensions():
+    extendee = 'ait.core.cmd.Cmd'
+    extendor = 'tests.ait.core.test_cfg.TestCmd'
+    cfg_yml = YAML()
+
+    cfg_yml += f"""extensions:
+        {extendee}: {extendor}"""
+
+    config = cfg.AitConfig(data=cfg_yml)
+    extensions = config.get('extensions', False)
+    assert extensions
+    assert extendee in extensions
+    assert extensions.get(extendee) == extendor
+
+class TestCmd():
+    pass

--- a/tests/ait/core/test_extensions.py
+++ b/tests/ait/core/test_extensions.py
@@ -1,0 +1,78 @@
+import os, sys, yaml, platform, pytest, logging
+
+import ait
+from ait.core import cfg, cmd, util
+
+@pytest.fixture()
+def test_dict():
+    CMDDICT_TEST = """
+- !Command
+  name:      SEQ_ENABLE_DISABLE
+  opcode:    0x0042
+  arguments:
+    - !Argument
+      name:  sequence_id
+      type:  MSB_U16
+      bytes: [0, 1]
+
+    - !Argument
+      name:  enable
+      type:  U8
+      bytes: 2
+      enum:
+        0: DISABLED
+        1: ENABLED
+"""
+    yield cmd.CmdDict(CMDDICT_TEST)
+
+@pytest.fixture(scope='module')
+def extended_config_yaml():
+    extendee = 'ait.core.cmd.Cmd'
+    extendor = 'tests.ait.core.test_extensions.TruthyCmd'
+    cfg=f"""
+    default:
+        leapseconds:
+            filename: leapseconds.dat
+
+    {sys.platform}:
+        ISS:
+            bticard: 6
+
+    {platform.node().split(".")[0]}:
+        ISS:
+            apiport: 1234
+
+    extensions:
+        {extendee}: {extendor}
+
+    """
+    return cfg
+
+@pytest.fixture(scope='module')
+def cfg_from_string(extended_config_yaml):
+    def tempFile():
+        from tests.ait.core import TestFile
+        with TestFile(data=extended_config_yaml) as filename:
+            config = cfg.AitConfig(filename)
+            config.reload()
+        return config
+    old_cfg = ait.config
+    ait.config = tempFile()
+    cmd.init_ext()
+    yield
+    ait.config = old_cfg
+
+@pytest.fixture
+def opNames(test_dict):
+    names = [i.name for i in test_dict.opcodes.values()]
+    return names
+
+class TruthyCmd(cmd.Cmd):
+    def encode(self):
+        return True
+
+def test_extensions(cfg_from_string, test_dict, opNames):
+    op = test_dict.create(opNames[0],0,0)
+    truthy_encode = op.encode()
+    assert isinstance(truthy_encode, bool)
+    assert truthy_encode


### PR DESCRIPTION
Fixes bug where the extensions map would be deleted from config map.
This prevented extensions from instantiating.
