### PR TITLE
Issue-394 Add DSN paths to ait-create-dirs

### DIFF
--- a/ait/core/cfg.py
+++ b/ait/core/cfg.py
@@ -332,6 +332,14 @@ class AitConfig(object):
             data = self._config["data"]
             for k in data:
                 paths[k] = data[k]["path"]
+
+            data = self._config.get("dsn",{}).get("cfdp",{}).get("datasink",{})
+            for k in data:
+                paths[k] = data[k]["path"]
+
+            data = self._config.get("dsn",{}).get("cfdp",{})
+            if data: paths["mib"] = data["mib"]["path"]
+
         except KeyError as e:
             raise AitConfigMissing(str(e))
         except Exception as e:


### PR DESCRIPTION
Add capability for ait-create-dirs to create the directories specified by the DSN blocks in config.yaml

Add DSN config.yaml path entries to AitConfig._datapaths
ait-create-dirs will now be able to create directories for the DSN block.