### PR TITLE
testing nested includes during test for 'dirty' (pickle)

### DIFF
--- a/ait/core/util.py
+++ b/ait/core/util.py
@@ -127,11 +127,11 @@ class ObjectCache(object):
             if self.dirty:
                 self._dict = self._loader(self.filename)
                 self.cache()
-                print('FILES MODIFIED - MAKE NEW PICKLE CACHE')
+                ait.log.debug('FILES MODIFIED - MAKE NEW PICKLE CACHE')
             else:
                 with open(self.cachename, "rb") as stream:
                     self._dict = pickle.load(stream)
-                    print('LOAD PICKLE CACHE.')
+                    ait.log.debug('LOAD PICKLE CACHE.')
 
         return self._dict
 

--- a/ait/core/util.py
+++ b/ait/core/util.py
@@ -59,10 +59,8 @@ class ObjectCache(object):
 
     @property
     def dirty(self):
-        """True if the cache needs to be updated, False otherwise"""
-        return not os.path.exists(self.cachename) or (
-            os.path.getmtime(self.filename) > os.path.getmtime(self.cachename)
-        )
+        """True if the pickle cache needs to be updated, False to use pickle binary"""
+        return self.check_yaml_timestamps(self.filename, self.cachename)
 
     @property
     def filename(self):
@@ -76,19 +74,64 @@ class ObjectCache(object):
         with open(self.cachename, "wb") as output:
             pickle.dump(self._dict, output, -1)
 
+    def check_yaml_timestamps(self, yaml_file_name, cache_name):
+        """
+        Checks YAML configuration file timestamp and any 'included' YAML configuration file
+        timestamps against the pickle cache file.
+        The term 'dirty' means that a yaml file has a more recent timestamp than the pickle
+        cache file.  If a file is found to be dirty the response will indicate that a new
+        pickle cache file must be generated.  As soon as one file is found to be 'dirty'
+        the flag indicating 'dirty' will be returned.  If a file_name is found to be 'clean'
+        the pickle binary will be loaded.
+
+        param yaml_file_name: str
+            Name of the yaml configuration file to be tested
+        param cache_name: str
+            Filename with path to the cached pickle file for this config file.
+
+        return: boolean
+            True/False indicating 'dirty' (update pickle cache)
+
+        """
+
+        # If no pickle cache exists return True to make a new one.
+        if not os.path.exists(cache_name):
+            return True
+        # Has the yaml config file has been modified since the creation of the pickle cache
+        if os.path.getmtime(yaml_file_name) > os.path.getmtime(cache_name):
+            return True
+        # Get the directory of the yaml config file to be parsed
+        dir_name = os.path.dirname(yaml_file_name)
+        # Open the yaml config file to look for '!includes' to be tested on the next iteration
+        with open(yaml_file_name, "r") as file:
+            try:
+                for line in file:
+                    if not line.strip().startswith("#") and "!include" in line:
+                        check = self.check_yaml_timestamps(
+                            os.path.join(dir_name, line.strip().split(" ")[2]), cache_name)
+                        if check:
+                            return True
+            except RecursionError as e:   # TODO Python 3.7 does not catch this error.
+                print(f'ERROR: {e}: Infinite loop: check that yaml config files are not looping '
+                      f'back and forth to one another thought the "!include" statements.')
+        return False
+
     def load(self):
         """Loads the Python object
 
         Loads the Python object, either via loader(filename) or the
         pickled cache file, whichever was modified most recently.
         """
+
         if self._dict is None:
             if self.dirty:
                 self._dict = self._loader(self.filename)
                 self.cache()
+                print('FILES MODIFIED - MAKE NEW PICKLE CACHE')
             else:
                 with open(self.cachename, "rb") as stream:
                     self._dict = pickle.load(stream)
+                    print('LOAD PICKLE CACHE.')
 
         return self._dict
 

--- a/ait/core/util.py
+++ b/ait/core/util.py
@@ -96,9 +96,11 @@ class ObjectCache(object):
 
         # If no pickle cache exists return True to make a new one.
         if not os.path.exists(cache_name):
+            ait.log.debug(f'No pickle cache exists, make a new one')
             return True
         # Has the yaml config file has been modified since the creation of the pickle cache
         if os.path.getmtime(yaml_file_name) > os.path.getmtime(cache_name):
+            ait.log.debug(f'{yaml_file_name} modified - make a new pickle cash')
             return True
         # Get the directory of the yaml config file to be parsed
         dir_name = os.path.dirname(yaml_file_name)
@@ -114,6 +116,7 @@ class ObjectCache(object):
             except RecursionError as e:   # TODO Python 3.7 does not catch this error.
                 print(f'ERROR: {e}: Infinite loop: check that yaml config files are not looping '
                       f'back and forth to one another thought the "!include" statements.')
+        ait.log.debug('Load pickle binary.')
         return False
 
     def load(self):
@@ -127,11 +130,9 @@ class ObjectCache(object):
             if self.dirty:
                 self._dict = self._loader(self.filename)
                 self.cache()
-                ait.log.debug('FILES MODIFIED - MAKE NEW PICKLE CACHE')
             else:
                 with open(self.cachename, "rb") as stream:
                     self._dict = pickle.load(stream)
-                    ait.log.debug('LOAD PICKLE CACHE.')
 
         return self._dict
 


### PR DESCRIPTION
This change request is based on issue-371. Users were having problems with the serialization of their config files. It was found that the included config files were not being tested for creation date, so when an included config file was modified, the need to recreate the binary (.pkl file) was not being recognized by the software. This resulted in and out of date config file being loaded. This has now been fixed with the addition of a short method (check_yaml_timestamps()) and a change to the 'dirty' property, which, now calls check_yaml_timestamps() in the ObjectCache class in util.py.

Fixes #371 