### PR TITLE
Integ sunrise dtf21

### DIFF
--- a/ait/core/cmd.py
+++ b/ait/core/cmd.py
@@ -559,7 +559,7 @@ def YAMLCtor_include(loader, node):  # noqa
     name = os.path.join(os.path.dirname(loader.name), node.value)
     data = None
     with open(name, "r") as f:
-        data = yaml.load(f)
+        data = yaml.load(f, Loader=yaml.Loader)
     return data
 
 

--- a/ait/core/dtype.py
+++ b/ait/core/dtype.py
@@ -406,7 +406,7 @@ class ArrayType(object):
 
         return self.type.decode(bytes[start:stop], raw)
 
-    def encode(self, *args):
+    def encode(self, args):
         """encode(value1[, ...]) -> bytes
 
         Encodes the given values to a sequence of bytes according to this

--- a/ait/core/server/client.py
+++ b/ait/core/server/client.py
@@ -37,11 +37,13 @@ class ZMQClient(object):
         # calls gevent.Greenlet or gs.DatagramServer __init__
         super(ZMQClient, self).__init__(**kwargs)
 
-    def publish(self, msg):
+    def publish(self, msg, topic=None):
         """
         Publishes input message with client name as topic.
         """
-        msg = utils.encode_message(self.name, msg)
+        if not topic:
+            topic = self.name
+        msg = utils.encode_message(topic, msg)
         if msg is None:
             log.error(f"{self} unable to encode msg {msg} for send.")
             return

--- a/ait/core/tlm.py
+++ b/ait/core/tlm.py
@@ -567,6 +567,8 @@ class PacketDefinition(json.SlotSerializer):
         "ccsds",
         "constants",
         "desc",
+        "opcode",
+        "apid",
         "fields",
         "fieldmap",
         "uid",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,13 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python           = '~3.7'
+python           = '~3.8'
 bottle           = '0.12.17'
 jsonschema       = '3.0.2'
 pyyaml           = '5.1.2'
 requests         = '>= 2.22.0'
 greenlet         = '0.4.16'
-gevent           = '1.4.0'
+gevent           = '1.5.0'
 gevent-websocket = '0.10.1'
 pyzmq            = '18.1.0'
 


### PR DESCRIPTION
This PR encompasses all changes made to this project leading up to SunRISE DTF21

- Add APID and Opcode Telemetry Fields
- Add capability for plugins to publish to arbitrary topic
- Specify YAML loader in order to load include blocks
- Bump python version to match KMC Client
- Bump gevent version for Python 3.8 support