### PR TITLE
Issue #370: Use TempFile class throughout test suite

### DIFF
--- a/ait/core/table.py
+++ b/ait/core/table.py
@@ -16,9 +16,10 @@ import hashlib
 import io
 import os
 import pickle
+import yaml
 
 import ait
-import yaml
+
 from ait.core import dmc
 from ait.core import dtype
 from ait.core import log

--- a/ait/core/util.py
+++ b/ait/core/util.py
@@ -26,6 +26,8 @@ import stat
 import sys
 import time
 import zlib
+import tempfile
+import warnings
 
 import pickle
 
@@ -137,7 +139,7 @@ def check_yaml_timestamps(yaml_file_name, cache_name):
                         os.path.join(dir_name, line.strip().split(" ")[2]), cache_name)
                     if check:
                         return True
-        except RecursionError as e:   # TODO Python 3.7 does not catch this error.
+        except RecursionError as e:
             print(f'ERROR: {e}: Infinite loop: check that yaml config files are not looping '
                   f'back and forth to one another thought the "!include" statements.')
     return False
@@ -497,6 +499,55 @@ def listAllFiles(directory, suffix=None, abspath=False):  # noqa
             files.append(filepath)
 
     return files
+
+
+class TestFile:
+    """TestFile
+
+    TestFile is a Python Context Manager for quickly creating test
+    data files that delete when a test completes, either successfully
+    or unsuccessfully.
+
+    Example:
+
+        with TestFile(data) as filename:
+            # filename (likely something like '/var/tmp/tmp.1.uNqbVJ') now
+            # contains data.
+            assert load(filename)
+
+    Whether the above assert passes or throws AssertionError, filename
+    will be deleted.
+    """
+
+    def __init__(self, data, options):
+        """
+        Creates a new TestFile and writes data to a temporary file.
+
+        Parameters:
+            data: text/binary
+                the data to be written to the temporary file
+
+            options: str
+                file operations for reading, writing, concatenating the temporary file
+        """
+        self._filename = None
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self._tfile = tempfile.NamedTemporaryFile(mode=options)
+            self._filename = self._tfile.name
+
+        with open(self._filename, "w") as output:
+            output.write(data)
+
+    def __enter__(self):
+        """Enter the runtime context and return filename."""
+        return self._filename
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Exit the runtime context and delete filename."""
+        self._tfile.close()
+        self._filename = None
 
 
 class YAMLValidationError(Exception):

--- a/tests/ait/core/__init__.py
+++ b/tests/ait/core/__init__.py
@@ -1,7 +1,7 @@
 # Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
 # Bespoke Link to Instruments and Small Satellites (BLISS)
 #
-# Copyright 2014, by the California Institute of Technology. ALL RIGHTS
+# Copyright 2022, by the California Institute of Technology. ALL RIGHTS
 # RESERVED. United States Government Sponsorship acknowledged. Any
 # commercial use must be negotiated with the Office of Technology Transfer
 # at the California Institute of Technology.
@@ -11,71 +11,23 @@
 # laws and regulations. User has the responsibility to obtain export licenses,
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
-"""
-AIT Unit and Functional Tests
 
-The ait.test module provides functional and unit tests for ait modules.
-"""
+"""AIT Unit and Functional Tests"""
 import logging
-import os
-import tempfile
-import warnings
-
-import ait.core
 
 
 def setUp():
-    """Set up tests.
-
-    Turn logging level to CRITICAL: due to failure test cases, there
-    are many verbose log messages that are useful in context.
+    """
+    Set up tests:
+        Turn logging level to CRITICAL: due to failure test cases, there
+        are many verbose log messages that are useful in context.
     """
     logging.getLogger("ait").setLevel(logging.CRITICAL)
 
 
 def tearDown():
-    """Tear down tests.
-
-    Turn logging level back to INFO.
+    """
+    Tear down tests:
+        Turn logging level back to INFO.
     """
     logging.getLogger("ait").setLevel(logging.INFO)
-
-
-class TestFile:
-    """TestFile
-
-    TestFile is a Python Context Manager for quickly creating test
-    data files that delete when a test completes, either successfully
-    or unsuccessfully.
-
-    Example:
-
-        with TestFile(data) as filename:
-            # filename (likely something like '/var/tmp/tmp.1.uNqbVJ') now
-            # contains data.
-            assert load(filename)
-
-    Whether the above assert passes or throws AssertionError, filename
-    will be deleted.
-    """
-
-    def __init__(self, data):
-        """Creates a new TestFile and writes data to a temporary file."""
-        self._filename = None
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            self._tfile = tempfile.NamedTemporaryFile(mode="wt")
-            self._filename = self._tfile.name
-
-        with open(self._filename, "wt") as output:
-            output.write(data)
-
-    def __enter__(self):
-        """Enter the runtime context and return filename."""
-        return self._filename
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        """Exit the runtime context and delete filename."""
-        self._tfile.close()
-        self._filename = None

--- a/tests/ait/core/server/test_apid_routing.py
+++ b/tests/ait/core/server/test_apid_routing.py
@@ -1,63 +1,27 @@
 import unittest
-import warnings
-import tempfile
+
 from unittest.mock import patch
 from ait.core import log
 from ait.core.server.plugins.apid_routing import APIDRouter
+from ait.core.util import TestFile
 
-class TestFile:
-    """TestFile
 
-    TestFile is a Python Context Manager for quickly creating test
-    data files that delete when a test completes, either successfully
-    or unsuccessfully.
-
-    Example:
-
-        with TestFile(data) as filename:
-            # filename (likely something like '/var/tmp/tmp.1.uNqbVJ') now
-            # contains data.
-            assert load(filename)
-
-    Whether the above assert passes or throws AssertionError, filename
-    will be deleted.
-    """
-
-    def __init__(self, data):
-        """Creates a new TestFile and writes data to a temporary file."""
-        self._filename = None
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            self._tfile = tempfile.NamedTemporaryFile(mode="wt")
-            self._filename = self._tfile.name
-
-        with open(self._filename, "wt") as output:
-            output.write(data)
-
-    def __enter__(self):
-        """Enter the runtime context and return filename."""
-        return self._filename
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        """Exit the runtime context and delete filename."""
-        self._tfile.close()
-        self._filename = None
-
-class test_packet:
+class TestPacket:
     def __init__(self, apid=0):
         self.apid = apid
+
 
 def create_test_dict(number_of_packets = 150):
     test_dict = {}
     for i in range(1, number_of_packets+1):
         packet_name = f"Packet_{i}"
-        test_dict[packet_name] = test_packet(apid = i)
+        test_dict[packet_name] = TestPacket(apid = i)
     return test_dict
+
 
 class TestPacketRouting(unittest.TestCase):
     def routing_table_yaml():
-        '''
+        """
         # Call this function to return the yaml string below
 
         output_topics:
@@ -71,11 +35,12 @@ class TestPacketRouting(unittest.TestCase):
                     - 9
                 - exclude:
                     - 6
-        '''
+        """
 
         pass
-    
-    with TestFile(data=routing_table_yaml.__doc__) as filename:
+
+    test_file = TestFile(routing_table_yaml.__doc__, "wt")
+    with test_file as filename:
 
         def new_init(self, routing_table=None, default_topic=None):
             self.default_topic = default_topic

--- a/tests/ait/core/server/test_apid_routing.py
+++ b/tests/ait/core/server/test_apid_routing.py
@@ -39,9 +39,7 @@ class TestPacketRouting(unittest.TestCase):
 
         pass
 
-    test_file = TestFile(routing_table_yaml.__doc__, "wt")
-    with test_file as filename:
-
+    with TestFile(routing_table_yaml.__doc__, "wt") as filename:
         def new_init(self, routing_table=None, default_topic=None):
             self.default_topic = default_topic
 

--- a/tests/ait/core/test_cfg.py
+++ b/tests/ait/core/test_cfg.py
@@ -232,8 +232,7 @@ def test_flatten():
 
 
 def test_load_yaml():
-    test_file = TestFile(YAML(), "w+")
-    with test_file as filename:
+    with TestFile(YAML(), "w+") as filename:
         assert cfg.load_yaml(filename) == cfg.load_yaml(data=YAML())
 
 
@@ -288,8 +287,7 @@ def test_AitConfig():
     path = "bin/ait-orbits"
     assert_AitConfig(config, path)
 
-    test_file = TestFile(YAML(), "w+")
-    with test_file as filename:
+    with TestFile(YAML(), "w+") as filename:
         config = cfg.AitConfig(filename)
         assert_AitConfig(config, path, filename)
         config.reload()

--- a/tests/ait/core/test_cfg.py
+++ b/tests/ait/core/test_cfg.py
@@ -16,7 +16,7 @@ import sys
 import time
 
 from ait.core import cfg
-from tests.ait.core import TestFile
+from ait.core.util import TestFile
 
 
 def YAML():
@@ -232,7 +232,8 @@ def test_flatten():
 
 
 def test_load_yaml():
-    with TestFile(data=YAML()) as filename:
+    test_file = TestFile(YAML(), "w+")
+    with test_file as filename:
         assert cfg.load_yaml(filename) == cfg.load_yaml(data=YAML())
 
 
@@ -287,9 +288,9 @@ def test_AitConfig():
     path = "bin/ait-orbits"
     assert_AitConfig(config, path)
 
-    with TestFile(data=YAML()) as filename:
+    test_file = TestFile(YAML(), "w+")
+    with test_file as filename:
         config = cfg.AitConfig(filename)
         assert_AitConfig(config, path, filename)
-
         config.reload()
         assert_AitConfig(config, path, filename)

--- a/tests/ait/core/test_pcap.py
+++ b/tests/ait/core/test_pcap.py
@@ -32,8 +32,7 @@ TmpFilename = None
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    test_file = TestFile('', "wb")
-    with test_file as filename:
+    with TestFile('', "wb") as filename:
         TmpFilename = filename
 
 

--- a/tests/ait/core/test_pcap.py
+++ b/tests/ait/core/test_pcap.py
@@ -11,29 +11,30 @@
 # laws and regulations. User has the responsibility to obtain export licenses,
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
-import gevent.monkey
-
-gevent.monkey.patch_all()
 
 import datetime
 import os
 import struct
-import time
 import warnings
 import time
-import tempfile
 
 from unittest import mock
 
+from gevent import monkey
+
 from ait.core import dmc, pcap
+from ait.core.util import TestFile
+
+monkey.patch_all()
 
 TmpFile = None
 TmpFilename = None
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    TmpFile = tempfile.NamedTemporaryFile(mode="wb")
-    TmpFilename = TmpFile.name
+    test_file = TestFile('', "wb")
+    with test_file as filename:
+        TmpFilename = filename
 
 
 def testPCapGlobalHeader():

--- a/tests/ait/core/test_table.py
+++ b/tests/ait/core/test_table.py
@@ -1,12 +1,11 @@
 import datetime as dt
 import inspect
-import os.path
-import tempfile
 import unittest
 
 import ait.core.dmc as dmc
 import ait.core.dtype as dtype
 from ait.core import table
+from ait.core.util import TestFile
 
 test_table = """
 - !FSWTable
@@ -72,12 +71,11 @@ test_table = """
 class TestTableEncode(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.table_defn_path = os.path.join(tempfile.gettempdir(), "test_table.yaml")
-
-        with open(cls.table_defn_path, "w") as infile:
-            infile.write(test_table)
-
-        cls.tabdict = table.FSWTabDict(cls.table_defn_path)
+        # The TestFile class is in util.py uses tempfile.NamedTemporaryFile() to create
+        # a temporary file that will be automatically deleted at the end of the tests
+        test_file = TestFile(test_table, "rt")
+        with test_file as file_name:
+            cls.tabdict = table.FSWTabDict(file_name)
 
     def test_enum_encode(self):
         defn = self.tabdict["test_type"]
@@ -172,12 +170,13 @@ class TestTableEncode(unittest.TestCase):
         4,5,6
         """
 
-        tmp_table_input = os.path.join(tempfile.gettempdir(), "test_table.txt")
-        with open(tmp_table_input, "w") as in_file:
-            in_file.write(table_data)
+        test_file = TestFile("test_table.txt", "w+")
+        with test_file as file_name:
+            with open(file_name, "w") as in_file:
+                assert in_file.write(table_data)
 
-        with open(tmp_table_input, "r") as in_file:
-            encoded = defn.encode(file_in=in_file)
+            with open(file_name, "r") as in_file:
+                encoded = defn.encode(file_in=in_file)
 
         assert len(encoded) == 13
 
@@ -200,7 +199,7 @@ class TestTableEncode(unittest.TestCase):
         assert encoded[11] == 5
         assert encoded[12] == 6
 
-        os.remove(tmp_table_input)
+        self.assertRaises(StopIteration)
 
     def test_encode_file_with_hdr(self):
         defn = self.tabdict["test_type"]
@@ -212,14 +211,15 @@ class TestTableEncode(unittest.TestCase):
 
         hdr_vals = [13, 12, 11]
 
-        tmp_table_input = os.path.join(tempfile.gettempdir(), "test_table.txt")
-        with open(tmp_table_input, "w") as in_file:
-            in_file.write(table_data)
+        test_file = TestFile("test_table.txt", "a+")
+        with test_file as temp_file_name:
+            with open(temp_file_name, "w") as in_file:
+                assert in_file.write(table_data)
 
-        with open(tmp_table_input, "r") as in_file:
-            encoded = defn.encode(file_in=in_file, hdr_vals=hdr_vals)
+            with open(temp_file_name, "r") as in_file:
+                encoded = defn.encode(file_in=in_file, hdr_vals=hdr_vals)
 
-        assert len(encoded) == 13
+            assert len(encoded) == 13
 
         # Check header
         assert encoded[0] == 13
@@ -240,18 +240,13 @@ class TestTableEncode(unittest.TestCase):
         assert encoded[11] == 5
         assert encoded[12] == 6
 
-        os.remove(tmp_table_input)
-
 
 class TestTableDecode(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.table_defn_path = os.path.join(tempfile.gettempdir(), "test_table.yaml")
-
-        with open(cls.table_defn_path, "w") as infile:
-            infile.write(test_table)
-
-        cls.tabdict = table.FSWTabDict(cls.table_defn_path)
+        test_file = TestFile(test_table, "rt")
+        with test_file as file_name:
+            cls.tabdict = table.FSWTabDict(file_name)
 
     def test_decode_binary(self):
         defn = self.tabdict["test_type"]
@@ -283,12 +278,13 @@ class TestTableDecode(unittest.TestCase):
         table_data = ["13,12,11", "1,2,TEST_ENUM_3", "4,5,TEST_ENUM_0"]
         encoded = defn.encode(text_in=table_data)
 
-        bin_file = os.path.join(tempfile.gettempdir(), "test_table_in.bin")
-        with open(bin_file, "wb") as out_file:
-            out_file.write(encoded)
+        binary_test_file = TestFile("test_table_in.bin", "wb+")
+        with binary_test_file as temp_bin_file:
+            with open(temp_bin_file, "wb") as out_file:
+                out_file.write(encoded)
 
-        with open(bin_file, "rb") as out_file:
-            decoded = defn.decode(file_in=out_file)
+            with open(temp_bin_file, "rb") as out_file:
+                 decoded = defn.decode(file_in=out_file)
 
         # Check header
         assert decoded[0][0] == 13
@@ -311,12 +307,13 @@ class TestTableDecode(unittest.TestCase):
         table_data = ["13,12,11", "1,2,TEST_ENUM_3", "4,5,TEST_ENUM_0"]
         encoded = defn.encode(text_in=table_data)
 
-        bin_file = os.path.join(tempfile.gettempdir(), "test_table_in.bin")
-        with open(bin_file, "wb") as out_file:
-            out_file.write(encoded)
+        binary_test_file = TestFile("test_table_in.bin", "wb+")
+        with binary_test_file as temp_bin_file:
+            with open(temp_bin_file, "wb") as out_file:
+                assert out_file.write(encoded)
 
-        with open(bin_file, "rb") as out_file:
-            decoded = defn.decode(file_in=out_file, raw=True)
+            with open(temp_bin_file, "rb") as out_file:
+                decoded = defn.decode(file_in=out_file, raw=True)
 
         # Check header
         assert decoded[0][0] == 13
@@ -364,69 +361,65 @@ class TestBadEnumHandling(unittest.TestCase):
                 3: TEST_ENUM_3
                 4: TEST_ENUM_0
         """
-        table_defn_path = os.path.join(
-            tempfile.gettempdir(), "test_table_dupe_enum.yaml"
-        )
 
-        with open(table_defn_path, "w") as infile:
-            infile.write(test_table)
+        test_file = TestFile("test_table_dupe_enum.yaml", "wt")
+        with test_file as temp_test_file:
+            with open(temp_test_file, "w") as infile:
+                assert infile.write(test_table)
 
-        with self.assertLogs("ait", level="ERROR") as cm:
-            tabdict = table.FSWTabDict(table_defn_path)
-            assert len(cm.output) == 1
+            with self.assertLogs("ait", level="ERROR") as cm:
+                tabdict = table.FSWTabDict(temp_test_file)
+                assert len(cm.output) == 1
 
 
 class TestTableTimeHandling(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.table_defn_path = os.path.join(
-            tempfile.gettempdir(), "test_time_table.yaml"
-        )
-
-        with open(cls.table_defn_path, "w") as infile:
-            infile.write(
-                inspect.cleandoc(
+        test_file = TestFile("test_time_table.yaml", "wt")
+        with test_file as temp_test_file:
+            with open(temp_test_file, "w") as infile:
+                assert infile.write(
+                    inspect.cleandoc(
+                        """
+                    - !FSWTable
+                      name: test_type
+                      delimiter: ","
+                      header:
+                        - !FSWColumn
+                          name: MAGIC_NUM
+                          desc: The first column in our header
+                          type:  U8
+                          bytes: 0
+                        - !FSWColumn
+                          name: UPTYPE
+                          desc: The second column in our header
+                          type:  U8
+                          bytes: 1
+                        - !FSWColumn
+                          name: VERSION
+                          desc: The third column in our header
+                          type:  U8
+                          bytes: 2
+                      columns:
+                        - !FSWColumn
+                          name: COLUMN_ONE
+                          desc: First FSW Table Column
+                          type:  TIME64
+                          bytes: [0,7]
+                        - !FSWColumn
+                          name: COLUMN_TWO
+                          desc: Second FSW Table Column
+                          type:  TIME40
+                          bytes: [8,12]
+                        - !FSWColumn
+                          name: COLUMN_THREE
+                          desc: Third FSW Table Column
+                          type:  TIME32
+                          bytes: [13,16]
                     """
-                - !FSWTable
-                  name: test_type
-                  delimiter: ","
-                  header:
-                    - !FSWColumn
-                      name: MAGIC_NUM
-                      desc: The first column in our header
-                      type:  U8
-                      bytes: 0
-                    - !FSWColumn
-                      name: UPTYPE
-                      desc: The second column in our header
-                      type:  U8
-                      bytes: 1
-                    - !FSWColumn
-                      name: VERSION
-                      desc: The third column in our header
-                      type:  U8
-                      bytes: 2
-                  columns:
-                    - !FSWColumn
-                      name: COLUMN_ONE
-                      desc: First FSW Table Column
-                      type:  TIME64
-                      bytes: [0,7]
-                    - !FSWColumn
-                      name: COLUMN_TWO
-                      desc: Second FSW Table Column
-                      type:  TIME40
-                      bytes: [8,12]
-                    - !FSWColumn
-                      name: COLUMN_THREE
-                      desc: Third FSW Table Column
-                      type:  TIME32
-                      bytes: [13,16]
-                """
+                    )
                 )
-            )
-
-        cls.tabdict = table.FSWTabDict(cls.table_defn_path)
+            cls.tabdict = table.FSWTabDict(temp_test_file)
 
     def test_end_to_end_time_handling(self):
         defn = self.tabdict["test_type"]

--- a/tests/ait/core/test_table.py
+++ b/tests/ait/core/test_table.py
@@ -73,8 +73,7 @@ class TestTableEncode(unittest.TestCase):
     def setUpClass(cls):
         # The TestFile class is in util.py uses tempfile.NamedTemporaryFile() to create
         # a temporary file that will be automatically deleted at the end of the tests
-        test_file = TestFile(test_table, "rt")
-        with test_file as file_name:
+        with TestFile(test_table, "rt") as file_name:
             cls.tabdict = table.FSWTabDict(file_name)
 
     def test_enum_encode(self):
@@ -170,8 +169,7 @@ class TestTableEncode(unittest.TestCase):
         4,5,6
         """
 
-        test_file = TestFile("test_table.txt", "w+")
-        with test_file as file_name:
+        with TestFile("test_table.txt", "w+") as file_name:
             with open(file_name, "w") as in_file:
                 assert in_file.write(table_data)
 
@@ -211,8 +209,7 @@ class TestTableEncode(unittest.TestCase):
 
         hdr_vals = [13, 12, 11]
 
-        test_file = TestFile("test_table.txt", "a+")
-        with test_file as temp_file_name:
+        with TestFile("test_table.txt", "a+") as temp_file_name:
             with open(temp_file_name, "w") as in_file:
                 assert in_file.write(table_data)
 
@@ -244,8 +241,7 @@ class TestTableEncode(unittest.TestCase):
 class TestTableDecode(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        test_file = TestFile(test_table, "rt")
-        with test_file as file_name:
+        with TestFile(test_table, "rt") as file_name:
             cls.tabdict = table.FSWTabDict(file_name)
 
     def test_decode_binary(self):
@@ -278,8 +274,7 @@ class TestTableDecode(unittest.TestCase):
         table_data = ["13,12,11", "1,2,TEST_ENUM_3", "4,5,TEST_ENUM_0"]
         encoded = defn.encode(text_in=table_data)
 
-        binary_test_file = TestFile("test_table_in.bin", "wb+")
-        with binary_test_file as temp_bin_file:
+        with TestFile("test_table_in.bin", "wb+") as temp_bin_file:
             with open(temp_bin_file, "wb") as out_file:
                 out_file.write(encoded)
 
@@ -307,8 +302,7 @@ class TestTableDecode(unittest.TestCase):
         table_data = ["13,12,11", "1,2,TEST_ENUM_3", "4,5,TEST_ENUM_0"]
         encoded = defn.encode(text_in=table_data)
 
-        binary_test_file = TestFile("test_table_in.bin", "wb+")
-        with binary_test_file as temp_bin_file:
+        with TestFile("test_table_in.bin", "wb+") as temp_bin_file:
             with open(temp_bin_file, "wb") as out_file:
                 assert out_file.write(encoded)
 
@@ -362,8 +356,7 @@ class TestBadEnumHandling(unittest.TestCase):
                 4: TEST_ENUM_0
         """
 
-        test_file = TestFile("test_table_dupe_enum.yaml", "wt")
-        with test_file as temp_test_file:
+        with TestFile("test_table_dupe_enum.yaml", "wt") as temp_test_file:
             with open(temp_test_file, "w") as infile:
                 assert infile.write(test_table)
 
@@ -375,8 +368,7 @@ class TestBadEnumHandling(unittest.TestCase):
 class TestTableTimeHandling(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        test_file = TestFile("test_time_table.yaml", "wt")
-        with test_file as temp_test_file:
+        with TestFile("test_time_table.yaml", "wt") as temp_test_file:
             with open(temp_test_file, "w") as infile:
                 assert infile.write(
                     inspect.cleandoc(

--- a/tests/ait/core/test_tlm.py
+++ b/tests/ait/core/test_tlm.py
@@ -11,17 +11,18 @@
 # laws and regulations. User has the responsibility to obtain export licenses,
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
-import gevent.monkey
+# gevent.monkey.patch_all()
 
-gevent.monkey.patch_all()
-
-import os
 import csv
+import os
 import struct
 
+from gevent import monkey
 import pytest
 
 from ait.core import tlm
+
+monkey.patch_all()
 
 
 class TestTlmDictWriter(object):


### PR DESCRIPTION
In unit tests removed all code using _'tempfile'_ and replaced with code using the _TestFile_ class.
Moved _TestFile_ class from _tests/ait/core/__init__.py_ to _ait/core/util.py_.
Modified _TestFile_ class to include on _'options'_ argument for file creation options (e.g. "w+", "wb+",...)
Factored out redundante _TestFile_ class in _test/ait/core/server/test_apid_rounting.py_ and used the common class in _util.py_
Did some minor clean up of import orders, 1 change to a class name, and a couple of docstrings to more closely match PEP 8 style guide.
Verified no _'tempfile'_ imports exist in the _'tests'_ directory structure
Ran all the unittests


Updated the syntax for calling the Context Manager to match docstrings.

Fixes #370 