### PR TITLE
Issue 448: Fix existing flake8 findings

### DIFF
--- a/ait/core/server/plugins/apid_routing.py
+++ b/ait/core/server/plugins/apid_routing.py
@@ -6,6 +6,7 @@ import yaml
 from ait.core.server.plugins import Plugin
 from ait.core import tlm, log
 
+
 class APIDRouter(Plugin):
     '''
     Routes CCSDS packets by APID according to a routing table defined by a yaml file.
@@ -20,7 +21,7 @@ class APIDRouter(Plugin):
         inputs:
             - AOS_to_CCSDS
         default_topic: default_ccsds_tlm_topic
-        routing_table: 
+        routing_table:
             path: packet_routing_table.yaml
 
     example routing table .yaml file:
@@ -75,7 +76,7 @@ class APIDRouter(Plugin):
         publishes incoming CCSDS packets to the routes specified in the routing table
 
         :param input_data: CCSDS packet as bytes
-        :type input_data: bytes, bytearray 
+        :type input_data: bytes, bytearray
         '''
         packet_apid = self.get_packet_apid(input_data)
         topics = self.routing_table_object[packet_apid]
@@ -170,7 +171,7 @@ class APIDRouter(Plugin):
         error = None
 
         for packet_name in tlm_dict:
-            packet_apid = tlm_dict[packet_name].apid #assuming apid is defined in dictionary
+            packet_apid = tlm_dict[packet_name].apid  # assuming apid is defined in dictionary
             routing_table[packet_apid] = [self.default_topic]
 
         if routing_table_path is None:
@@ -187,10 +188,10 @@ class APIDRouter(Plugin):
             return None
 
         for telem_stream_entry in yaml_file_as_dict["output_topics"]:
-            #telem_stream_entry is a dict with one entry
+            # telem_stream_entry is a dict with one entry
             for telem_stream_name in telem_stream_entry:
                 for value in telem_stream_entry[telem_stream_name]:
-                    if isinstance(value, int): #assume integer value is apid
+                    if isinstance(value, int):  # assume integer value is apid
                         apid = value
                         routing_table = self.add_topic_to_table(routing_table, apid, telem_stream_name)
                     elif isinstance(value, dict):

--- a/ait/core/util.py
+++ b/ait/core/util.py
@@ -120,7 +120,7 @@ def check_yaml_timestamps(yaml_file_name, cache_name):
     """
     # If no pickle cache exists return True to make a new one.
     if not os.path.exists(cache_name):
-        log.debug(f'No pickle cache exists, make a new one')
+        log.debug('No pickle cache exists, make a new one')
         return True
     # Has the yaml config file has been modified since the creation of the pickle cache
     if os.path.getmtime(yaml_file_name) > os.path.getmtime(cache_name):
@@ -513,4 +513,3 @@ class YAMLError(Exception):
         self.message = arg
 
         log.error(self.message)
-


### PR DESCRIPTION
Fixes #448. 

```
(ait_python37_venv) bseto@MT-304784 core % git push origin issue-448
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check for merge conflicts................................................Passed
Debug Statements (Python)................................................Passed
Reorder python imports...............................(no files to check)Skipped
mypy.....................................................................Passed
black................................................(no files to check)Skipped
flake8...................................................................Passed
AIT TLM YAML check.......................................................Passed
AIT CMD YAML check.......................................................Passed
AIT EVR YAML check.......................................................Passed
AIT LIMITS YAML check....................................................Passed
Tests....................................................................Passed
Enumerating objects: 15, done.
Counting objects: 100% (15/15), done.
Delta compression using up to 16 threads
Compressing objects: 100% (8/8), done.
Writing objects: 100% (8/8), 680 bytes | 680.00 KiB/s, done.
Total 8 (delta 6), reused 0 (delta 0)
remote: Resolving deltas: 100% (6/6), completed with 6 local objects.
remote:
remote: Create a pull request for 'issue-448' on GitHub by visiting:
remote:      https://github.com/bkseto/AIT-Core/pull/new/issue-448
remote:
To github.com:bkseto/AIT-Core.git
 * [new branch]      issue-448 -> issue-448
```