### PR TITLE
Issue #428 - Fix readthedocs build

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,3 @@
+sphinx-rtd-theme
+sphinxcontrib-httpdomain
+

--- a/doc/source/api_intro.rst
+++ b/doc/source/api_intro.rst
@@ -113,7 +113,7 @@ The API's Instrument interface provides users with an access point for monitorin
 
 The input streams that send messages to this topic can be configured via the **server.api-telemetry-streams** field. This field should be a list of input stream names which output their messages in the Packet-UID-annotated format that the built-in :class:`PacketHandler` / :class:`CCSDSPacketHandler` handlers use.
 
-.. code-block::
+.. code-block:: none
 
     server:
         api-telemetry-streams:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,6 +12,10 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import gevent
+import gevent.monkey
+gevent.monkey.patch_all()
+
 import sys
 import os
 

--- a/doc/source/plugin_PacketAccumulator.rst
+++ b/doc/source/plugin_PacketAccumulator.rst
@@ -11,6 +11,7 @@ Configuration
 Add the following template to the plugins block of your config.yaml and customize as necessary.
 
 .. code-block:: none
+
     - plugin:
       name: ait.core.server.plugins.PacketAccumulator.PacketAccumulator
       inputs:

--- a/doc/source/plugin_PacketPadder.rst
+++ b/doc/source/plugin_PacketPadder.rst
@@ -10,6 +10,7 @@ Configuration
 Add and customize the following template in your config.yaml
 
 .. code-block:: none
+
 	- plugin:
           name: ait.core.server.plugins.PacketPadder.PacketPadder
           inputs:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,3 +7,5 @@ python:
     extra_requirements:
         - docs
         - tests
+    install:
+        - requirements: doc/requirements.txt


### PR DESCRIPTION
After a series of trial and error attempts, it seems we now should have AIT-Core readthedocs working.

It seems the main issues were:

1) We need to tell readthedocs to install Sphinx dependencies: sphinx-rtd-theme, sphinxcontrib-httpdomain
...via a requirements.txt.
We also had to update the ReadTheDocs admin settings to tell system about the requirements file.
https://readthedocs.org/dashboard/ait-core/advanced/

2) To resolve a recursion error when DMC loads the leapseconds file, we have to monkey-patch Sphinx, and this is done via adding that to the conf.py file

Also made some minor updates to a few RST files to get rid of some of the warnings.

Final proof of a successful docs build can be found here: https://readthedocs.org/projects/ait-core/builds/17445166/

Fixes #428 



