### PR TITLE
Issue #376 - Add extension support to dtype.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ To view the documentation, open ``doc/build/html/index.html`` in a web browser. 
 
 If you need to update the auto-generated documentation you can run the following command to rebuild all of the package documentation::
 
-    sphinx-apidoc --separate --force --no-toc -o doc/source ait ait/core/server/test ait/core/test
+    sphinx-apidoc --separate --force --no-toc -o doc/source ait --implicit-namespaces
 
 Please make sure to update the docs if changes in a ticket result in the documentation being out of date.
 

--- a/ait/core/dtype.py
+++ b/ait/core/dtype.py
@@ -819,7 +819,7 @@ class CustomTypes:
     custom type should inherit from CustomTypes, implement `get()` so their
     types can be exposed, and configure AIT's extensions to use their class.
 
-    Custom classes must inherit from PrimitiveType. For examples of "custom" 
+    Custom classes must inherit from PrimitiveType. For examples of "custom"
     types look at the implementation of the `ComplexTypeMap` classes. All of
     these build on top of PrimitiveType in some way.
     '''
@@ -847,7 +847,11 @@ def get_cdt(typename):
 
 
 def get(typename):
-    """Returns the PrimitiveType or ComplexType for typename or None."""
+    """Returns the type for typename or None.
+
+    `get()` checks primitive types, then complex types, and finally custom
+    user defined types (via CustomTypes extension) for the typename.
+    """
     dt = get_pdt(typename) or get_cdt(typename) or USER_DEFN_TYPES.get(typename)
 
     if dt is None:
@@ -862,4 +866,4 @@ util.__init_extensions__(__name__, globals())
 
 # Note, this must be defined after the `util.__init_extensions__` call in order
 # for the magical createXXX function to exist.
-USER_DEFN_TYPES = createCustomTypes()
+USER_DEFN_TYPES = createCustomTypes()  # type: ignore[name-defined] # noqa: F821

--- a/ait/core/dtype.py
+++ b/ait/core/dtype.py
@@ -12,6 +12,9 @@
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
 
+from typing import Optional
+from ait.core import util
+
 """AIT Primitive Data Types (PDT)
 
 The ait.core.dtype module provides definitions and functions for
@@ -123,7 +126,7 @@ PrimitiveTypeFormats = {
 }
 
 
-class PrimitiveType(object):
+class PrimitiveType:
     """PrimitiveType
 
     A PrimitiveType contains a number of fields that provide information
@@ -807,6 +810,29 @@ ComplexTypeMap = {
 }
 
 
+class CustomTypes:
+    '''Pseudo-ABC for users to inject custom types into AIT
+
+    CustomTypes is the vector through which users can inject custom types that
+    they create into the toolkit. `dtype.get` is used throughout AIT to fetch
+    the appropriate class for a given data type. Users that want to create a
+    custom type should inherit from CustomTypes, implement `get()` so their
+    types can be exposed, and configure AIT's extensions to use their class.
+
+    Custom classes must inherit from PrimitiveType. For examples of "custom" 
+    types look at the implementation of the `ComplexTypeMap` classes. All of
+    these build on top of PrimitiveType in some way.
+    '''
+
+    def get(self, typename: str) -> Optional[PrimitiveType]:
+        '''Retrieve an instance of a type's class given its name
+
+        Maps a class name to an instance of its respective class. Should
+        return None if no match is found.
+        '''
+        return None
+
+
 def get_pdt(typename):
     """Returns the PrimitiveType for typename or None."""
     if typename not in PrimitiveTypeMap and typename.startswith("S"):
@@ -822,7 +848,7 @@ def get_cdt(typename):
 
 def get(typename):
     """Returns the PrimitiveType or ComplexType for typename or None."""
-    dt = get_pdt(typename) or get_cdt(typename)
+    dt = get_pdt(typename) or get_cdt(typename) or USER_DEFN_TYPES.get(typename)
 
     if dt is None:
         pdt, nelems = ArrayType.parse(typename)
@@ -830,3 +856,10 @@ def get(typename):
             dt = ArrayType(pdt, nelems)
 
     return dt
+
+
+util.__init_extensions__(__name__, globals())
+
+# Note, this must be defined after the `util.__init_extensions__` call in order
+# for the magical createXXX function to exist.
+USER_DEFN_TYPES = createCustomTypes()

--- a/doc/source/ait.core.bin.rst
+++ b/doc/source/ait.core.bin.rst
@@ -5,6 +5,7 @@ Submodules
 ----------
 
 .. toctree::
+   :maxdepth: 4
 
    ait.core.bin.ait_bsc
    ait.core.bin.ait_bsc_create_handler

--- a/doc/source/ait.core.rst
+++ b/doc/source/ait.core.rst
@@ -5,6 +5,7 @@ Subpackages
 -----------
 
 .. toctree::
+   :maxdepth: 4
 
    ait.core.bin
    ait.core.server
@@ -13,6 +14,7 @@ Submodules
 ----------
 
 .. toctree::
+   :maxdepth: 4
 
    ait.core.api
    ait.core.bsc

--- a/doc/source/ait.core.server.config.rst
+++ b/doc/source/ait.core.server.config.rst
@@ -1,0 +1,7 @@
+ait.core.server.config module
+=============================
+
+.. automodule:: ait.core.server.config
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/ait.core.server.handlers.rst
+++ b/doc/source/ait.core.server.handlers.rst
@@ -5,6 +5,7 @@ Submodules
 ----------
 
 .. toctree::
+   :maxdepth: 4
 
    ait.core.server.handlers.ccsds_packet_handler
    ait.core.server.handlers.packet_handler

--- a/doc/source/ait.core.server.plugins.PacketAccumulator.rst
+++ b/doc/source/ait.core.server.plugins.PacketAccumulator.rst
@@ -1,0 +1,7 @@
+ait.core.server.plugins.PacketAccumulator module
+================================================
+
+.. automodule:: ait.core.server.plugins.PacketAccumulator
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/ait.core.server.plugins.PacketPadder.rst
+++ b/doc/source/ait.core.server.plugins.PacketPadder.rst
@@ -1,0 +1,7 @@
+ait.core.server.plugins.PacketPadder module
+===========================================
+
+.. automodule:: ait.core.server.plugins.PacketPadder
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/ait.core.server.plugins.apid_routing.rst
+++ b/doc/source/ait.core.server.plugins.apid_routing.rst
@@ -1,5 +1,5 @@
-ait.core.server.plugins.apid_routing module
-======================================
+ait.core.server.plugins.apid\_routing module
+============================================
 
 .. automodule:: ait.core.server.plugins.apid_routing
    :members:

--- a/doc/source/ait.core.server.plugins.rst
+++ b/doc/source/ait.core.server.plugins.rst
@@ -5,11 +5,14 @@ Submodules
 ----------
 
 .. toctree::
+   :maxdepth: 4
 
+   ait.core.server.plugins.PacketAccumulator
+   ait.core.server.plugins.PacketPadder
+   ait.core.server.plugins.apid_routing
    ait.core.server.plugins.data_archive
    ait.core.server.plugins.limit_monitor
    ait.core.server.plugins.openmct
-   ait.core.server.plugins.apid_routing
 
 Module contents
 ---------------

--- a/doc/source/ait.core.server.process.rst
+++ b/doc/source/ait.core.server.process.rst
@@ -1,5 +1,5 @@
 ait.core.server.process module
-=============================
+==============================
 
 .. automodule:: ait.core.server.process
    :members:

--- a/doc/source/ait.core.server.rst
+++ b/doc/source/ait.core.server.rst
@@ -5,6 +5,7 @@ Subpackages
 -----------
 
 .. toctree::
+   :maxdepth: 4
 
    ait.core.server.handlers
    ait.core.server.plugins
@@ -13,9 +14,11 @@ Submodules
 ----------
 
 .. toctree::
+   :maxdepth: 4
 
    ait.core.server.broker
    ait.core.server.client
+   ait.core.server.config
    ait.core.server.handler
    ait.core.server.plugin
    ait.core.server.process

--- a/doc/source/ait.rst
+++ b/doc/source/ait.rst
@@ -1,17 +1,12 @@
-ait package
-===========
+ait namespace
+=============
+
+.. py:module:: ait
 
 Subpackages
 -----------
 
 .. toctree::
+   :maxdepth: 4
 
    ait.core
-
-Module contents
----------------
-
-.. automodule:: ait
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/doc/source/command_intro.rst
+++ b/doc/source/command_intro.rst
@@ -197,7 +197,7 @@ enum (optional):
 The fixed constructor allows you to define constant values in your command.
 
 type:
-    A **string** specifying the data type of the argument. You can see all the valid primitive types that will be accepted here by looking at ``ait.core.dtype.PrimitiveTypes``.
+    A **string** specifying the data type of the argument. You can see all the valid primitive types that will be accepted here by looking at :doc:`AIT Data Types <data_types>`.
 
 bytes:
     Specifies which byte(s) in the command filled by this constant. This can be specified as a single integer or as a list of integers (in the case of a range of bytes). Byte values must be specified in correct numerical order when a command has multiple Arguments or Fixed attributes.

--- a/doc/source/data_types.rst
+++ b/doc/source/data_types.rst
@@ -1,0 +1,90 @@
+AIT Data Types
+==============
+
+AIT provides a number of built in data types and functionality for extending the toolkit with your own custom types. The default data types provided aim to cover the majority of the basic types you would expect to find in a packet of data. These so-called **Primitive Types** are all built on top of `ait.core.dtype.PrimitiveType`. More complicated type fields can be built on top of `PrimitiveType` by inheriting from it and implementing custom encode and decode functionality. Types such as `ait.core.dtype.CMD16` do exactly this.
+
+Built-in Types
+--------------
+
+AIT provides a variety of primitive types that cover the many of fields encountered in data packets. These are defined in **ait.core.dtype.PrimitiveTypes**.
+
+.. code-block:: python
+
+   [
+        'I8',
+        'LSB_D64',
+        'LSB_F32',
+        'LSB_I16',
+        'LSB_I32',
+        'LSB_I64',
+        'LSB_U16',
+        'LSB_U32',
+        'LSB_U64',
+        'MSB_D64',
+        'MSB_F32',
+        'MSB_I16',
+        'MSB_I32',
+        'MSB_I64',
+        'MSB_U16',
+        'MSB_U32',
+        'MSB_U64',
+        'U8'
+   ]
+
+AIT also provides some **Complex Types** that are built on top of various primitive types. The default types provided tie in with AIT's Command and EVR types as well as some CCSDS time formats.
+
+.. code-block:: python
+
+   [
+        'CMD16',
+        'EVR16',
+        'TIME8',
+        'TIME32',
+        'TIME40',
+        'TIME64'
+   ]
+
+Custom Types
+------------
+
+If the default AIT types aren't meeting your needs you can define custom types and integrate them with the toolkit via the :doc:`Extensions <extensions>` mechanism.
+
+Consider the following example which creates a custom 24-bit MSB type.
+
+.. code-block:: python
+
+   from typing import Optional
+
+   from ait.core import dtype
+
+   class MyCustomTypes(dtype.CustomTypes):
+       def get(self, typename: str) -> Optional[dtype.PrimitiveType]:
+           match typename:
+               case 'My24BitMSB':
+                   return My24BitMSB()
+
+           return None
+
+
+   class My24BitMSB(dtype.PrimitiveType):
+       def __init__(self):
+           # Current implementation requires that you pass a valid type here
+           # even if it's not accurate. Manually overwrite stuff after the call
+           # so it's correct. I.e., this isn't actually an MSB_U32!
+           super(My24BitMSB, self).__init__('MSB_U32')
+           self._nbits = 24
+           self._nbytes = 3
+
+       def encode(self, value: int):
+           return (value & 0xFFFFFF).to_bytes(3, byteorder='big')
+
+       def decode(self, bytes, raw=False):
+           return int.from_bytes(bytes[:3], byteorder='big')
+
+To add a custom type you must extend **dtype.CustomTypes** with your own implementation and return an instance of your custom types. The above would be added as extension by placing the following in your **config.yaml** file. As always with extensions, the module containing the relevant class must be findable by Python.
+
+.. code-block:: yaml
+
+   default:
+       extensions:
+          ait.core.dtype.CustomTypes: yourmodule.MyCustomTypes

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,6 +18,7 @@ Visit the :doc:`Installation and Environment Configuration <installation>` guide
    server_architecture
    Command Dictionary Introduction <command_intro>
    Telemetry Dictionary Introduction <telemetry_intro>
+   Data Types <data_types>
    Ground Script API Introduction <api_intro>
    EVR Introduction <evr_intro>
    limits_intro

--- a/doc/source/telemetry_intro.rst
+++ b/doc/source/telemetry_intro.rst
@@ -228,7 +228,7 @@ name:
     A **string** denoting the name of this field in the packet. Note: Do not use the name "time". "time" is a reserved name used in the backend databases for recording the time of entries. To avoid conflicts of this nature, you should avoid using generic names or prepend names with a subsystem identifier.
 
 type:
-    A **string** specifying the data type for the section of the packet in which this field is located. You can see all the valid primitive types that will be accepted here by looking at ``ait.dtype.PrimitiveTypes``. You can see examples of how *type* is used in the `Example Telemetry Packet Definition`_ section.
+    A **string** specifying the data type for the section of the packet in which this field is located. You can see all the valid primitive types that will be accepted here by looking at :doc:`AIT Data Types <data_types>`. You can see examples of how *type* is used in the `Example Telemetry Packet Definition`_ section.
 
     .. note::
 


### PR DESCRIPTION
Update dtype.py to support user extensions via `dtype.CustomTypes`.
Calls to `dtype.get` now also check `CustomTypes.get` for class
instances. Users can extend `dtypeCustomTypes` via the normal
toolkit extensions interface.

Default `dtype.CustomTypes.get` always returns None so normal
behavior remains unchanged.

Add top-level Data Type documentation page. This page now explicitly
lists the built-in types that AIT supports. Additionally, information on
how to use the newly added extension support in dtypes is included as
well.

Update README's `sphinx-apidoc` call instructions to use
`--implicit-namespaces`. This is necessary to ensure that the `ait`
namespace is picked up and included in the API docs that are generated.
Without this files will be written starting with the `core` module. Update
API docs with latest changes.
