### PR TITLE
Issue #467 - Add baseline GH Actions build

### DIFF
--- a/.github/workflows/full_build.yaml
+++ b/.github/workflows/full_build.yaml
@@ -1,0 +1,42 @@
+name: Full Test and Lint
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ait_build:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Poetry Install
+        run: |
+          pipx install poetry
+          poetry --version
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          # Caching is currently causing the tox build to fail for 3.10.
+          # Specifically, the `lint` run claims that it's unable to find
+          # pre-commit. Oddly enough, the install for 3.10 shows that
+          # pre-commit is installed and the tox run claims that it doesn't
+          # need to install anything.
+          #cache: 'poetry'
+      - name: Install Package
+        run: poetry install
+      - name: Set AIT Config
+        run: echo "AIT_CONFIG=./config/config.yaml" >> $GITHUB_ENV
+      - name: "Install dependencies"
+        run: |
+          set -xe
+          python -VV
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox-gh-actions
+      - name: Run Tox
+        run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,15 @@ envlist =
     py310
     docs
     lint
+
 isolated_build = True
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310, docs, lint, distcheck
 
 [testenv]
 setenv = AIT_CONFIG = {toxinidir}/config/config.yaml


### PR DESCRIPTION
Add a default build for any push to master or pull request that runs
the full `tox` build. This includes the test suite for all supported
python versions, the docs build, and the linting pipeline.

This is sufficient for a first pass but there are a couple of things we
might want to poke at. I could not get `actions/setup-python` caching of
poetry dependencies to work with `tox-gh-actions`. The lint run kept
failing because it couldn't find `pre-commit` even though it seemed to
have been installed properly. Should poke at this in a follow on ticket.

Would also be good to get a better build running to test package
deployment and the like. Bundling everything up and shipping it off to
test.pypi would be great. I'd also like to get a release build
integrated so we aren't manually doing that. Automatic CHANGELOG updates
after a push to master or PR merge would also be great.

Resolve #467
