### PR TITLE
Issue #491 - Add logger type annotations for GUI mypy checks

### DIFF
--- a/ait/core/log.py
+++ b/ait/core/log.py
@@ -23,6 +23,7 @@ import sys
 import socket
 import datetime
 import time
+from typing import Callable, Optional
 
 import logging
 import logging.handlers
@@ -316,10 +317,10 @@ def notice(*args, **kwargs):
 # type `Any` addresses mypy issues where log calls are marked as
 # "None" being not callable.
 logger = None
-crit = None
-debug = None
-error = None
-info = None
-warn = None
+crit: Optional[Callable[[str], str]] = None
+debug: Optional[Callable[[str], str]] = None
+error: Optional[Callable[[str], str]] = None
+info: Optional[Callable[[str], str]] = None
+warn: Optional[Callable[[str], str]] = None
 
 init()

--- a/ait/core/log.py
+++ b/ait/core/log.py
@@ -39,6 +39,13 @@ logging.addLevelName(NOTICE, "NOTICE")
 logging.addLevelName(COMMAND, "COMMAND")
 logging.addLevelName(PROGRAM, "PROGRAM")
 
+logger = None
+crit: Optional[Callable[[str], str]] = None
+debug: Optional[Callable[[str], str]] = None
+error: Optional[Callable[[str], str]] = None
+info: Optional[Callable[[str], str]] = None
+warn: Optional[Callable[[str], str]] = None
+
 
 class LogFormatter(logging.Formatter):
     """LogFormatter
@@ -312,15 +319,5 @@ def program(*args, **kwargs):
 def notice(*args, **kwargs):
     logger.log(NOTICE, *args, **kwargs)
 
-
-# These are "guaranteed" at runtime to be not-None. Marking this as
-# type `Any` addresses mypy issues where log calls are marked as
-# "None" being not callable.
-logger = None
-crit: Optional[Callable[[str], str]] = None
-debug: Optional[Callable[[str], str]] = None
-error: Optional[Callable[[str], str]] = None
-info: Optional[Callable[[str], str]] = None
-warn: Optional[Callable[[str], str]] = None
 
 init()


### PR DESCRIPTION
Add minor type annotations in log.py to keep type checking happing in
AIT-GUI.

Resolve #491
