### PR TITLE
Fix issue 506 for reference to get_gps_offset_for_date().

### DIFF
--- a/ait/core/dmc.py
+++ b/ait/core/dmc.py
@@ -122,7 +122,7 @@ def to_gps_week_and_secs(timestamp=None) -> Tuple[int, int]:
     if timestamp is None:
         timestamp = datetime.datetime.utcnow()
 
-    leap = LeapSeconds.get_GPS_offset_for_date(timestamp)  # type: ignore
+    leap = LeapSeconds.get_gps_offset_for_date(timestamp)  # type: ignore
 
     secs_in_week = 604800
     delta = (timestamp - GPS_Epoch).total_seconds() + leap


### PR DESCRIPTION
Update for AIT-Core version 2.5.1 has a reference to get_GPS_offset_for_date(). This pull request fixes that to reference get_gps_offset_for_date().