### PR TITLE
Free the dependencies!

### DIFF
--- a/ait/core/cmd.py
+++ b/ait/core/cmd.py
@@ -18,10 +18,12 @@ The ait.core.cmd module provides commands and command dictionaries.
 Dictionaries contain command and argument definitions.
 """
 import os
+import atexit
 import struct
+import importlib
 from io import IOBase
+from contextlib import ExitStack
 
-import pkg_resources
 import yaml
 
 import ait
@@ -518,7 +520,10 @@ def getDefaultDictFilename():  # noqa
 
 
 def getDefaultSchema():  # noqa
-    return pkg_resources.resource_filename("ait.core", "data/cmd_schema.json")
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+    ref = importlib.resources.files("ait.core") / "data/cmd_schema.json"
+    return file_manager.enter_context(importlib.resources.as_file(ref))
 
 
 def getMaxCmdSize():  # noqa

--- a/ait/core/evr.py
+++ b/ait/core/evr.py
@@ -18,8 +18,10 @@ The ait.core.evr module is used to read the EVRs from a YAML file.
 """
 import os
 import re
+import atexit
+import importlib
+from contextlib import ExitStack
 
-import pkg_resources
 import yaml
 
 import ait.core
@@ -75,7 +77,10 @@ class EVRDict(dict):
 
 
 def getDefaultSchema():  # noqa
-    return pkg_resources.resource_filename("ait.core", "data/evr_schema.json")
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+    ref = importlib.resources.files("ait.core") / "data/evr_schema.json"
+    return file_manager.enter_context(importlib.resources.as_file(ref))
 
 
 def getDefaultDict(reload=False):  # noqa

--- a/ait/core/limits.py
+++ b/ait/core/limits.py
@@ -68,9 +68,11 @@ For example:
 
 """
 import os
+import atexit
+import importlib
 from io import IOBase
+from contextlib import ExitStack
 
-import pkg_resources
 import yaml
 
 import ait
@@ -224,7 +226,10 @@ def getDefaultDict(reload=False):  # noqa
 
 
 def getDefaultSchema():  # noqa
-    return pkg_resources.resource_filename("ait.core", "data/limits_schema.json")
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+    ref = importlib.resources.files("ait.core") / "data/limits_schema.json"
+    return file_manager.enter_context(importlib.resources.as_file(ref))
 
 
 def getDefaultDictFilename():  # noqa

--- a/ait/core/tlm.py
+++ b/ait/core/tlm.py
@@ -21,10 +21,12 @@ definitions.
 import collections.abc
 import csv
 import os
+import atexit
 import struct
+import importlib
 from io import IOBase
+from contextlib import ExitStack
 
-import pkg_resources
 import yaml
 
 import ait
@@ -1096,7 +1098,10 @@ def getDefaultDict(reload=False):  # noqa
 
 
 def getDefaultSchema():  # noqa
-    return pkg_resources.resource_filename("ait.core", "data/tlm_schema.json")
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+    ref = importlib.resources.files("ait.core") / "data/tlm_schema.json"
+    return file_manager.enter_context(importlib.resources.as_file(ref))
 
 
 def getDefaultDictFilename():  # noqa

--- a/ait/core/util.py
+++ b/ait/core/util.py
@@ -162,7 +162,7 @@ def __init_extensions__(modname, modsyms):  # noqa
                     modname, clsname = parts
                     module = pydoc.locate(modname)
                     if module is None:
-                        raise ImportError("No module named %d" % modname)
+                        raise ImportError("No module named %s" % modname)
                     create.cls = getattr(module, clsname)
                 if create.cls is None:
                     raise ImportError("No class named %s" % extname)

--- a/ait/core/util.py
+++ b/ait/core/util.py
@@ -62,7 +62,7 @@ class ObjectCache(object):
 
 if sys.platform == "win32":
     # On Windows, the best timer is time.clock
-    timer = time.clock
+    timer = time.perf_counter
 else:
     # On most other platforms the best timer is time.time
     timer = time.time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,17 +22,17 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python           = '>= 3.7 < 3.11'
-bottle           = '0.12.23'
-jsonschema       = '3.0.2'
-pyyaml           = '6.0.1'
+python           = '>=3.11'
+bottle           = '>=0.12.23'
+jsonschema       = '>=3.0.2'
+pyyaml           = '>=6.0.1'
 requests         = '>= 2.22.0'
-greenlet         = '1.1.3'
+greenlet         = '>=1.1.3'
 gevent           = '*'
-gevent-websocket = '0.10.1'
-pyzmq            = '24.0.0'
-gipc             = "^1.1.0"
-setproctitle = "^1.2.3"
+gevent-websocket = '>=0.10.1'
+pyzmq            = '>=24.0.0'
+gipc             = ">=1.1.0"
+setproctitle = ">=1.2.3"
 msgpack          = '*'
 
 [tool.poetry.dev-dependencies]

--- a/tests/ait/core/test_val.py
+++ b/tests/ait/core/test_val.py
@@ -16,7 +16,6 @@ import gevent.monkey
 gevent.monkey.patch_all()
 
 import os
-import pkg_resources
 import jsonschema
 
 import pytest
@@ -453,18 +452,20 @@ def testEvrValidation():
 def testTableValidation():
     # Validation test of current table configuration
     yml = ait.config.table.filename
-    schema = pkg_resources.resource_filename("ait.core", "data/table_schema.json")
-    msgs, v = validate_schema([yml, schema])
-    dispmsgs(msgs)
-    assert v
-    assert len(msgs) == 0
+    ref = importlib.resources.files("ait.core") / "data/table_schema.json"
+    with importlib.resources.as_file(ref) as schema:
+        msgs, v = validate_schema([yml, schema])
+        dispmsgs(msgs)
+        assert v
+        assert len(msgs) == 0
 
 
 def testLimitsValidation():
     # Validation test of current table configuration
     yml = ait.config.limits.filename
-    schema = pkg_resources.resource_filename("ait.core", "data/limits_schema.json")
-    msgs, v = validate_schema([yml, schema])
-    dispmsgs(msgs)
-    assert v
-    assert len(msgs) == 0
+    ref = importlib.resources.files("ait.core") / "data/limits_schema.json"
+    with importlib.resources.as_file(ref) as schema:
+        msgs, v = validate_schema([yml, schema])
+        dispmsgs(msgs)
+        assert v
+        assert len(msgs) == 0


### PR DESCRIPTION
Creating a PR for #545. 

There are a number of dependencies locked in the projects dependency specification. The current constraint on Python and other dependencies prevents any downstream projects from receiving security or bug fixes. AIT-Core itself also becomes non-installable on projects where another version of said dependency is already specified.

Current Stable Python version is 3.14. 