### PR TITLE
Fix signed integer min/max bounds in PrimitiveType

### DIFF
--- a/ait/core/dtype.py
+++ b/ait/core/dtype.py
@@ -172,8 +172,8 @@ class PrimitiveType:
             self._max = +sys.float_info.max
             self._min = -sys.float_info.max
         elif self.signed:
-            self._max = 2 ** (self.nbits - 1)
-            self._min = -1 * (self.max - 1)
+            self._max = 2 ** (self.nbits - 1) - 1
+            self._min = -1 * (self.max + 1)
         elif not self.string:
             self._max = 2**self.nbits - 1
             self._min = 0

--- a/tests/ait/core/test_dtype.py
+++ b/tests/ait/core/test_dtype.py
@@ -248,3 +248,33 @@ def testString():
 
     enc_ba = dt.encode("on-your-left")
     assert enc_ba
+
+
+def testSignedRange():
+    # An n-bit two's-complement signed integer is valid over
+    # [-2**(n-1), 2**(n-1) - 1]. Regression test for the min/max off-by-one
+    # that made validate() accept max+1 (which struct.pack rejects) and
+    # reject the true minimum.
+    for name in (
+        "I8",
+        "LSB_I16",
+        "MSB_I16",
+        "LSB_I32",
+        "MSB_I32",
+        "LSB_I64",
+        "MSB_I64",
+    ):
+        dt = dtype.get(name)
+        nbits = dt.nbits
+
+        assert dt.min == -(2 ** (nbits - 1))
+        assert dt.max == (2 ** (nbits - 1)) - 1
+
+        assert dt.validate(dt.min)
+        assert dt.validate(dt.max)
+        assert not dt.validate(dt.min - 1)
+        assert not dt.validate(dt.max + 1)
+
+        # The true minimum and maximum must round-trip through encode/decode.
+        assert dt.decode(dt.encode(dt.min)) == dt.min
+        assert dt.decode(dt.encode(dt.max)) == dt.max


### PR DESCRIPTION
I do supply-chain security work and was reading through the dtype module when the signed-integer bounds in `PrimitiveType.__init__` looked off by one:

```python
self._max = 2 ** (self.nbits - 1)
self._min = -1 * (self.max - 1)
```

For an n-bit two's complement integer the range is `[-2**(n-1), 2**(n-1) - 1]`, so for I8 this reports `[-127, 128]` instead of `[-128, 127]` (and likewise for the 16/32/64-bit signed types).

`validate()` uses these bounds directly, so today:

- `validate(128)` on I8 returns True, but `encode(128)` then fails in `struct.pack` (the `b` format requires -128..127). validate is meant to catch that.
- `validate(-128)` on I8 returns False, even though -128 is a legal int8 that encodes fine.

The fix sets max to `2**(n-1) - 1` and derives min as `-(max + 1)`. The unsigned and float branches are unchanged.

I added `tests/ait/core/test_dtype.py::testSignedRange`, which checks the bounds for each signed type and confirms the true min and max both validate and round-trip through encode/decode, while one past each end is rejected. Nothing in the existing dtype tests asserts these bounds, so this does not change any current expectation. `pytest tests/ait/core/test_dtype.py` is green with the new test included.
