### PR TITLE
Issue #557 - Updating readthedocs.yml to use v2 syntax

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,11 +1,19 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: doc/source/conf.py
+
 formats:
-    - none
+  - pdf
+  - epub
 
 python:
-    version: "3.11"
-    pip_install: true
-    extra_requirements:
-        - docs
-        - tests
-    install:
-        - requirements: doc/requirements.txt
+  install:
+    - method: pip
+      path: .
+    - requirements: doc/requirements.txt

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,7 +10,6 @@ sphinx:
 
 formats:
   - pdf
-  - epub
 
 python:
   install:


### PR DESCRIPTION
#557 - readthedocs builds have been failing for a while to do old config syntax. Updating to use v2, which is currently supported.